### PR TITLE
fix: import examples for t variable

### DIFF
--- a/docs/docs/i18n.md
+++ b/docs/docs/i18n.md
@@ -193,7 +193,7 @@ if (t.loading) {
 ```ts caption=i18n/usage/store
 // Svelte
 <script lang="ts">
-  import { t } from "$lib/i18n";
+  import t from "#i18n";
   // $t is the live translator function
 </script>
 <h1>{$t("greeting", { name: "Ada" })}</h1>
@@ -217,7 +217,7 @@ useEffect(() => t.subscribe(() => forceUpdate()), []);
 ### React
 
 ```tsx
-import { t } from "@/i18n";
+import t from "#i18n";
 
 export function Profile({ user }: { user: { name: string; since: number } }) {
   return (
@@ -237,7 +237,7 @@ export function Profile({ user }: { user: { name: string; since: number } }) {
 
 ```svelte
 <script lang="ts">
-  import { t } from "$lib/i18n";
+  import t from "#i18n";
   const change = () => t.locale.set("en-US");
 </script>
 
@@ -250,7 +250,7 @@ export function Profile({ user }: { user: { name: string; since: number } }) {
 
 ```ts
 <script setup lang="ts">
-import { t } from "@/i18n";
+import t from "#i18n";
 const switchLocale = () => t.locale.set("fr-FR");
 </script>
 


### PR DESCRIPTION
The import examples for React and Svelte have incorrect imports

E.G. for svelte: import { t } from "$lib/i18n"

should be

`import t from "#i18n"`