### PR TITLE
feat: jsondb db driver

### DIFF
--- a/packages/jsondb/package.json
+++ b/packages/jsondb/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@primate/jsondb",
+  "version": "0.1.0-pre",
+  "description": "JSON file databases for Primate",
+  "homepage": "https://primate.run/docs/database/jsondb",
+  "bugs": "https://github.com/primate-run/primate/issues",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/primate-run/primate",
+    "directory": "packages/jsondb"
+  },
+  "files": [
+    "/lib/**/*.js",
+    "/lib/**/*.d.ts",
+    "!/**/*.spec.*"
+  ],
+  "scripts": {
+    "build": "npm run clean && tsc",
+    "clean": "rm -rf ./lib",
+    "lint": "eslint .",
+    "prepublishOnly": "npm run build",
+    "test": "npx proby",
+    "test:bun": "bunx --bun proby",
+    "test:deno": "deno run -A npm:proby"
+  },
+  "dependencies": {
+    "@primate/core": "workspace:^",
+    "@rcompat/assert": "^0.10.0",
+    "@rcompat/fs": "^0.25.2",
+    "@rcompat/is": "^0.8.0"
+  },
+  "devDependencies": {
+    "@rcompat/type": "^0.14.0",
+    "pema": "workspace:^"
+  },
+  "peerDependencies": {
+    "primate": "workspace:^"
+  },
+  "imports": {
+    "#*": {
+      "@primate/source": "./src/private/*.ts",
+      "default": "./lib/private/*.js"
+    }
+  },
+  "exports": {
+    ".": {
+      "@primate/source": "./src/public/index.ts",
+      "default": "./lib/public/index.js"
+    }
+  }
+}

--- a/packages/jsondb/src/private/ColumnTypes.ts
+++ b/packages/jsondb/src/private/ColumnTypes.ts
@@ -1,0 +1,14 @@
+import type { JSONValue } from "@rcompat/type";
+
+type ColumnTypes = {
+  BIGINT: bigint;
+  BLOB: Blob;
+  BOOLEAN: boolean;
+  DATE: Date;
+  JSON: JSONValue;
+  NUMBER: number;
+  STRING: string;
+  URL: URL;
+};
+
+export type { ColumnTypes as default };

--- a/packages/jsondb/src/private/JsonDB.spec.ts
+++ b/packages/jsondb/src/private/JsonDB.spec.ts
@@ -1,0 +1,175 @@
+import JsonDB from "#JsonDB";
+import core_test from "@primate/core/db/test";
+import fs from "@rcompat/fs";
+import test from "@rcompat/test";
+import p from "pema";
+
+// Core test suite
+core_test(new JsonDB());
+
+// Custom tests for JSON-specific behavior
+
+const tmp_path = `/tmp/primate-jsondb-test-${Date.now()}`;
+const db = new JsonDB({ directory: tmp_path });
+
+const dt = {
+  u8: p.u8.datatype,
+  u32: p.u32.datatype,
+  u64: p.u64.datatype,
+  i64: p.i64.datatype,
+  string: p.string.datatype,
+  blob: p.blob.datatype,
+};
+
+const users_types = { id: dt.u32, name: dt.string, age: dt.u8 } as const;
+const users_as = { table: "json_test", pk: "id", types: users_types };
+
+test.ended(async () => {
+  db.close();
+  const dir = fs.ref(tmp_path);
+  if (await dir.exists()) {
+    await dir.remove({ recursive: true });
+  }
+});
+
+async function $(body: () => Promise<void>) {
+  await db.schema.create("json_test", { name: "id", generate: true },
+    users_types);
+  await body();
+  await db.schema.delete("json_test");
+}
+
+test.case("persists data to JSON file", async assert => {
+  await $(async () => {
+    await db.create(users_as, { id: 1, name: "Alice", age: 30 });
+
+    const ref = fs.ref(tmp_path).join("json_test.json");
+    assert(await ref.exists()).true();
+
+    const text = await ref.text();
+    const data = JSON.parse(text);
+    assert(data.length).equals(1);
+    assert(data[0].name).equals("Alice");
+  });
+});
+
+test.case("serializes BigInt as {__type:'bigint', value:string}", async assert => {
+  const bigint_types = { id: dt.u32, amount: dt.i64 } as const;
+  const bigint_as = { table: "bigint_test", pk: "id", types: bigint_types };
+
+  await db.schema.create("bigint_test", { name: "id", generate: true },
+    bigint_types);
+
+  await db.create(bigint_as, { id: 1, amount: 9007199254740993n });
+
+  const ref = fs.ref(tmp_path).join("bigint_test.json");
+  const text = await ref.text();
+  const data = JSON.parse(text);
+
+  assert(data[0].amount.__type).equals("bigint");
+  assert(data[0].amount.value).equals("9007199254740993");
+
+  await db.schema.delete("bigint_test");
+});
+
+test.case("serializes Blob as {__type:'blob', value:base64}", async assert => {
+  const blob_types = { id: dt.u32, data: dt.blob } as const;
+  const blob_as = { table: "blob_test", pk: "id", types: blob_types };
+
+  await db.schema.create("blob_test", { name: "id", generate: true },
+    blob_types);
+
+  const blob = new Blob([new Uint8Array([72, 101, 108, 108, 111])], {
+    type: "application/octet-stream",
+  });
+  await db.create(blob_as, { id: 1, data: blob });
+
+  const ref = fs.ref(tmp_path).join("blob_test.json");
+  const text = await ref.text();
+  const data = JSON.parse(text);
+
+  assert(data[0].data.__type).equals("blob");
+  // "Hello" in base64 is "SGVsbG8="
+  assert(data[0].data.value).equals("SGVsbG8=");
+
+  await db.schema.delete("blob_test");
+});
+
+test.case("survives reload from disk", async assert => {
+  const reload_types = { id: dt.u32, name: dt.string } as const;
+  const reload_as = { table: "reload_test", pk: "id", types: reload_types };
+
+  await db.schema.create("reload_test", { name: "id", generate: true },
+    reload_types);
+  await db.create(reload_as, { id: 1, name: "persisted" });
+
+  // create a new instance pointing to the same directory
+  const db2 = new JsonDB({ directory: tmp_path });
+  await db2.schema.create("reload_test", { name: "id", generate: true },
+    reload_types);
+
+  const rows = await db2.read(reload_as, { where: {} });
+  assert(rows.length).equals(1);
+  assert(rows[0].name).equals("persisted");
+
+  await db.schema.delete("reload_test");
+});
+
+test.case("deserializes BigInt from JSON on reload", async assert => {
+  const bi_types = { id: dt.u32, value: dt.u64 } as const;
+  const bi_as = { table: "bigint_reload", pk: "id", types: bi_types };
+
+  await db.schema.create("bigint_reload", { name: "id", generate: true },
+    bi_types);
+  await db.create(bi_as, { id: 1, value: 12345678901234n });
+
+  const db2 = new JsonDB({ directory: tmp_path });
+  await db2.schema.create("bigint_reload", { name: "id", generate: true },
+    bi_types);
+
+  const rows = await db2.read(bi_as, { where: {} });
+  assert(rows[0].value).equals(12345678901234n);
+
+  await db.schema.delete("bigint_reload");
+});
+
+test.case("deserializes Blob from JSON on reload", async assert => {
+  const bl_types = { id: dt.u32, data: dt.blob } as const;
+  const bl_as = { table: "blob_reload", pk: "id", types: bl_types };
+
+  await db.schema.create("blob_reload", { name: "id", generate: true },
+    bl_types);
+
+  const original = new Blob([new Uint8Array([1, 2, 3, 4, 5])], {
+    type: "application/octet-stream",
+  });
+  await db.create(bl_as, { id: 1, data: original });
+
+  const db2 = new JsonDB({ directory: tmp_path });
+  await db2.schema.create("blob_reload", { name: "id", generate: true },
+    bl_types);
+
+  const rows = await db2.read(bl_as, { where: {} });
+  const restored = rows[0].data as Blob;
+  const bytes = new Uint8Array(await restored.arrayBuffer());
+  assert(bytes.length).equals(5);
+  assert(bytes[0]).equals(1);
+  assert(bytes[4]).equals(5);
+
+  await db.schema.delete("blob_reload");
+});
+
+test.case("schema.delete removes JSON file", async assert => {
+  const del_types = { id: dt.u32, name: dt.string } as const;
+  const del_as = { table: "delete_test", pk: "id", types: del_types };
+
+  await db.schema.create("delete_test", { name: "id", generate: true },
+    del_types);
+  await db.create(del_as, { id: 1, name: "temp" });
+
+  const ref = fs.ref(tmp_path).join("delete_test.json");
+  assert(await ref.exists()).true();
+
+  await db.schema.delete("delete_test");
+  assert(await ref.exists()).false();
+});

--- a/packages/jsondb/src/private/JsonDB.spec.ts
+++ b/packages/jsondb/src/private/JsonDB.spec.ts
@@ -1,16 +1,16 @@
-import JsonDB from "#JsonDB";
+import JSONDB from "#JSONDB";
 import core_test from "@primate/core/db/test";
 import fs from "@rcompat/fs";
 import test from "@rcompat/test";
 import p from "pema";
 
 // Core test suite
-core_test(new JsonDB());
+core_test(new JSONDB());
 
 // Custom tests for JSON-specific behavior
 
 const tmp_path = `/tmp/primate-jsondb-test-${Date.now()}`;
-const db = new JsonDB({ directory: tmp_path });
+const db = new JSONDB({ directory: tmp_path });
 
 const dt = {
   u8: p.u8.datatype,
@@ -104,7 +104,7 @@ test.case("survives reload from disk", async assert => {
   await db.create(reload_as, { id: 1, name: "persisted" });
 
   // create a new instance pointing to the same directory
-  const db2 = new JsonDB({ directory: tmp_path });
+  const db2 = new JSONDB({ directory: tmp_path });
   await db2.schema.create("reload_test", { name: "id", generate: true },
     reload_types);
 
@@ -123,7 +123,7 @@ test.case("deserializes BigInt from JSON on reload", async assert => {
     bi_types);
   await db.create(bi_as, { id: 1, value: 12345678901234n });
 
-  const db2 = new JsonDB({ directory: tmp_path });
+  const db2 = new JSONDB({ directory: tmp_path });
   await db2.schema.create("bigint_reload", { name: "id", generate: true },
     bi_types);
 
@@ -145,7 +145,7 @@ test.case("deserializes Blob from JSON on reload", async assert => {
   });
   await db.create(bl_as, { id: 1, data: original });
 
-  const db2 = new JsonDB({ directory: tmp_path });
+  const db2 = new JSONDB({ directory: tmp_path });
   await db2.schema.create("blob_reload", { name: "id", generate: true },
     bl_types);
 

--- a/packages/jsondb/src/private/JsonDB.ts
+++ b/packages/jsondb/src/private/JsonDB.ts
@@ -22,14 +22,14 @@ function comparable(x: unknown) {
 function like_re(pattern: string, flags = "") {
   return new RegExp(
     "^" +
-      escape_re(pattern)
-        .replace(/\\%/g, "<<PERCENT>>")
-        .replace(/\\_/g, "<<UNDERSCORE>>")
-        .replace(/%/g, "[\\s\\S]*")
-        .replace(/_/g, "[\\s\\S]")
-        .replace(/<<PERCENT>>/g, "%")
-        .replace(/<<UNDERSCORE>>/g, "_") +
-      "$",
+    escape_re(pattern)
+      .replace(/\\%/g, "<<PERCENT>>")
+      .replace(/\\_/g, "<<UNDERSCORE>>")
+      .replace(/%/g, "[\\s\\S]*")
+      .replace(/_/g, "[\\s\\S]")
+      .replace(/<<PERCENT>>/g, "%")
+      .replace(/<<UNDERSCORE>>/g, "_") +
+    "$",
     flags,
   );
 }
@@ -186,7 +186,7 @@ const config_schema = p({
   directory: p.string.default("data"),
 });
 
-export default class JsonDB implements DB<Tables> {
+export default class JSONDB implements DB<Tables> {
   static config: typeof config_schema.input;
   #directory: FileRef;
   #tables: Tables = {};

--- a/packages/jsondb/src/private/JsonDB.ts
+++ b/packages/jsondb/src/private/JsonDB.ts
@@ -1,0 +1,502 @@
+import type { As, DataDict, DB, Schema, Sort, Types, With } from "@primate/core/db";
+import E from "@primate/core/db/errors";
+import assert from "@rcompat/assert";
+import type { FileRef } from "@rcompat/fs";
+import fs from "@rcompat/fs";
+import is from "@rcompat/is";
+import type { Dict, PartialDict } from "@rcompat/type";
+import p from "pema";
+
+type Tables = PartialDict<Dict[]>;
+
+function escape_re(s: string) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function comparable(x: unknown) {
+  if (is.date(x)) return x.getTime();
+  if (is.url(x)) return x.href;
+  return x as any;
+}
+
+function like_re(pattern: string, flags = "") {
+  return new RegExp(
+    "^" +
+      escape_re(pattern)
+        .replace(/\\%/g, "<<PERCENT>>")
+        .replace(/\\_/g, "<<UNDERSCORE>>")
+        .replace(/%/g, "[\\s\\S]*")
+        .replace(/_/g, "[\\s\\S]")
+        .replace(/<<PERCENT>>/g, "%")
+        .replace(/<<UNDERSCORE>>/g, "_") +
+      "$",
+    flags,
+  );
+}
+
+function match(record: Dict, where: Dict) {
+  return Object.entries(where).every(([k, v]) => {
+    const value = record[k];
+
+    if (v === null) return value === null || value === undefined;
+
+    if (is.dict(v)) {
+      if (value === null || value === undefined) return false;
+
+      for (const [op, op_val] of Object.entries(v)) {
+        switch (op) {
+          case "$like": {
+            if (!is.string(value)) return false;
+            if (!like_re(op_val as string).test(value)) return false;
+            break;
+          }
+
+          case "$ilike": {
+            if (!is.string(value)) return false;
+            if (!like_re(op_val as string, "i").test(value)) return false;
+            break;
+          }
+
+          case "$gte":
+            if (!(comparable(value) >= comparable(op_val))) return false;
+            break;
+
+          case "$gt":
+          case "$after":
+            if (!(comparable(value) > comparable(op_val))) return false;
+            break;
+
+          case "$lte":
+            if (!(comparable(value) <= comparable(op_val))) return false;
+            break;
+
+          case "$lt":
+          case "$before":
+            if (!(comparable(value) < comparable(op_val))) return false;
+            break;
+
+          case "$ne": {
+            if (is.date(value) && is.date(op_val)) {
+              if (value.getTime() === op_val.getTime()) return false;
+              break;
+            }
+            if (is.url(value) && is.url(op_val)) {
+              if (value.href === op_val.href) return false;
+              break;
+            }
+            if (value === op_val) return false;
+            break;
+          }
+
+          default:
+            throw E.operator_unknown(k, op);
+        }
+      }
+
+      return true;
+    }
+
+    if (is.date(value) && is.date(v)) return value.getTime() === v.getTime();
+    if (is.url(value) && is.url(v)) return value.href === v.href;
+
+    return value === v;
+  });
+}
+
+function filter(record: Dict, fields: string[]) {
+  return Object.fromEntries(
+    Object.entries(record).filter(([key]) => fields.includes(key)),
+  );
+}
+
+function to_sorted<T extends Dict>(d1: T, d2: T, sort: Sort) {
+  return Object.entries(sort)
+    .map(([k, value]) => [k, value === "asc" ? 1 : -1] as const)
+    .reduce((sorting, [field, direction]) => {
+      const left = d1[field] as T[keyof T];
+      const right = d2[field] as typeof left;
+      if (sorting !== 0) return sorting;
+      if (left === right) return sorting;
+      if (left < right) return -1 * direction;
+      return direction;
+    }, 0);
+}
+
+// JSON serialization for types that JSON can't represent natively
+
+async function prepare_for_json(rows: Dict[]): Promise<unknown[]> {
+  return Promise.all(rows.map(async row => {
+    const out: Dict = {};
+    for (const [key, value] of Object.entries(row)) {
+      if (typeof value === "bigint") {
+        out[key] = { __type: "bigint", value: String(value) };
+      } else if (value instanceof Blob) {
+        const bytes = new Uint8Array(await value.arrayBuffer());
+        let binary = "";
+        for (const byte of bytes) binary += String.fromCharCode(byte);
+        out[key] = { __type: "blob", value: btoa(binary) };
+      } else if (is.date(value)) {
+        out[key] = { __type: "datetime", value: value.toISOString() };
+      } else if (is.url(value)) {
+        out[key] = { __type: "url", value: value.href };
+      } else {
+        out[key] = value;
+      }
+    }
+    return out;
+  }));
+}
+
+function revive_from_json(rows: unknown[]): Dict[] {
+  return (rows as Dict[]).map(row => {
+    const out: Dict = {};
+    for (const [key, value] of Object.entries(row)) {
+      if (is.dict(value) && "__type" in value && "value" in value) {
+        switch (value.__type) {
+          case "bigint":
+            out[key] = BigInt(value.value as string);
+            break;
+          case "blob": {
+            const binary = atob(value.value as string);
+            const bytes = Uint8Array.from(
+              { length: binary.length },
+              (_, i) => binary.charCodeAt(i),
+            );
+            out[key] = new Blob([bytes], { type: "application/octet-stream" });
+            break;
+          }
+          case "datetime":
+            out[key] = new Date(value.value as string);
+            break;
+          case "url":
+            out[key] = new URL(value.value as string);
+            break;
+          default:
+            out[key] = value;
+        }
+      } else {
+        out[key] = value;
+      }
+    }
+    return out;
+  });
+}
+
+const config_schema = p({
+  directory: p.string.default("data"),
+});
+
+export default class JsonDB implements DB<Tables> {
+  static config: typeof config_schema.input;
+  #directory: FileRef;
+  #tables: Tables = {};
+  #types: PartialDict<Types> = {};
+
+  constructor(config?: typeof config_schema.input) {
+    const parsed = config_schema.parse(config);
+    this.#directory = fs.ref(parsed.directory);
+  }
+
+  get client() {
+    return this.#tables;
+  }
+
+  #ref(table: string): FileRef {
+    return this.#directory.join(`${table}.json`);
+  }
+
+  async #load(table: string): Promise<void> {
+    if (this.#tables[table] !== undefined) return;
+
+    const ref = this.#ref(table);
+    if (await ref.exists()) {
+      const text = await ref.text();
+      const raw = JSON.parse(text) as unknown[];
+      this.#tables[table] = revive_from_json(raw);
+    } else {
+      this.#tables[table] = [];
+    }
+  }
+
+  async #persist(table: string): Promise<void> {
+    const rows = this.#use(table);
+    const prepared = await prepare_for_json(rows);
+    const text = JSON.stringify(prepared, null, 2);
+
+    if (!await this.#directory.exists()) {
+      await this.#directory.create();
+    }
+
+    await this.#ref(table).write(text);
+  }
+
+  #use(table: string): Dict[] {
+    this.#tables[table] ??= [];
+    return this.#tables[table];
+  }
+
+  get schema(): Schema {
+    return {
+      create: async (table, _pk, types) => {
+        await this.#load(table);
+        this.#types[table] = types;
+      },
+      delete: async (table) => {
+        delete this.#tables[table];
+        delete this.#types[table];
+        const ref = this.#ref(table);
+        if (await ref.exists()) {
+          await ref.remove();
+        }
+      },
+      introspect: (table) => {
+        if (this.#tables[table] === undefined) return null;
+        const types = this.#types[table] ?? {};
+        return Object.fromEntries(
+          Object.entries(types).map(([field, type]) => [field, [type]]),
+        );
+      },
+      alter: (table, diff) => {
+        if (this.#types[table] === undefined) throw E.table_not_found(table);
+
+        const types = { ...this.#types[table] };
+        const { add, drop, rename } = diff;
+
+        for (const [field, type] of Object.entries(add)) types[field] = type;
+        for (const field of drop) delete types[field];
+        for (const [from, to] of rename) {
+          types[to] = types[from];
+          delete types[from];
+        }
+
+        this.#types[table] = types;
+      },
+    };
+  }
+
+  close() { }
+
+  #next_id(as: As) {
+    const table = this.#use(as.table);
+    const size = table.length;
+    const pk = assert.defined(as.pk);
+    const type = as.types[pk];
+
+    if (type === "uuid" || type === "uuid_v4" || type === "uuid_v7") {
+      return crypto.randomUUID();
+    } else if (["u64", "u128", "i64", "i128"].includes(type)) {
+      return size === 0 ? 0n : (table[size - 1][pk] as bigint) + 1n;
+    } else {
+      return size === 0 ? 0 : (table[size - 1][pk] as number) + 1;
+    }
+  }
+
+  async create<O extends Dict>(as: As, record: Dict): Promise<O> {
+    assert.nonempty(record);
+
+    await this.#load(as.table);
+    const table = this.#use(as.table);
+    const pk = as.pk;
+
+    let to_insert = record;
+
+    if (pk !== null && !(pk in record)) {
+      if (as.generate_pk === false) throw E.pk_required(pk);
+      to_insert = { ...record, [pk]: this.#next_id(as) };
+    }
+
+    if (pk !== null) {
+      const pv = to_insert[pk];
+      if (table.find(s => s[pk] === pv) !== undefined) {
+        throw E.pk_duplicate(pk);
+      }
+    }
+
+    table.push({ ...to_insert });
+    await this.#persist(as.table);
+
+    return to_insert as O;
+  }
+
+  read(as: As, args: {
+    count: true;
+    where: DataDict;
+    with?: never;
+  }): Promise<number>;
+  read(as: As, args: {
+    where: DataDict;
+    fields?: string[];
+    limit?: number;
+    sort?: Sort;
+    with?: With;
+  }): Promise<Dict[]>;
+  async read(as: As, args: {
+    count?: true;
+    where: DataDict;
+    fields?: string[];
+    limit?: number;
+    sort?: Sort;
+    with?: With;
+  }): Promise<Dict[] | number> {
+    assert.dict(args.where);
+
+    await this.#load(as.table);
+    const table = this.#use(as.table);
+    const matches = table.filter(r => match(r, args.where));
+
+    if (args.count === true) return matches.length;
+
+    const sort = args.sort ?? {};
+    const sorted = Object.keys(sort).length === 0
+      ? matches
+      : matches.toSorted((a, b) => to_sorted(a, b, sort));
+
+    const limit = args.limit ?? sorted.length;
+    const base_rows = sorted.slice(0, limit);
+
+    if (args.with === undefined) {
+      const fields = args.fields ?? [];
+      return fields.length === 0
+        ? base_rows
+        : base_rows.map(r => filter(r, fields));
+    }
+
+    assert.dict(args.with);
+
+    const base_fields = args.fields ?? [];
+    const out = base_rows.map(full =>
+      base_fields.length === 0 ? { ...full } : filter(full, base_fields),
+    );
+    const base_full = base_rows;
+
+    for (const [r_name, rel] of Object.entries(args.with)) {
+      const target_as = rel.as;
+      const kind = rel.kind;
+      const fk = rel.fk;
+      const reverse = rel.reverse === true;
+      const r_where = rel.where;
+      const r_sort = rel.sort;
+      const r_limit = rel.limit;
+      const r_fields = rel.fields ?? [];
+
+      await this.#load(target_as.table);
+      const target = this.#use(target_as.table);
+
+      function project_rel(row: Dict) {
+        if (r_fields.length === 0) return { ...row };
+        return filter(row, r_fields);
+      }
+
+      if (kind === "one" && reverse) {
+        const target_pk = target_as.pk;
+        if (target_pk === null) throw E.relation_requires_pk("target");
+
+        for (let i = 0; i < out.length; i++) {
+          const parent_full = base_full[i];
+          const fk_value = parent_full[fk];
+
+          if (fk_value == null) {
+            out[i][r_name] = null;
+            continue;
+          }
+
+          let candidates = target.filter(
+            t => t[target_pk] === fk_value && match(t, r_where),
+          );
+
+          if (r_sort !== undefined && Object.keys(r_sort).length > 0) {
+            candidates = candidates.toSorted((a, b) =>
+              to_sorted(a, b, r_sort),
+            );
+          }
+
+          if (r_limit !== undefined) candidates = candidates.slice(0, r_limit);
+
+          const got = candidates[0];
+          out[i][r_name] = got ? project_rel(got) : null;
+        }
+
+        continue;
+      }
+
+      const parent_pk = as.pk;
+      if (parent_pk === null) throw E.relation_requires_pk("parent");
+
+      const parent_keys = new Set(base_full.map(r => r[parent_pk]));
+      const grouped = new Map<unknown, Dict[]>();
+
+      for (const row of target) {
+        const key = row[fk];
+        if (!parent_keys.has(key)) continue;
+        if (!match(row, r_where)) continue;
+
+        const bucket = grouped.get(key);
+        if (bucket !== undefined) bucket.push(row);
+        else grouped.set(key, [row]);
+      }
+
+      for (let i = 0; i < out.length; i++) {
+        const parent_full = base_full[i];
+        const key = parent_full[parent_pk];
+
+        let rows = grouped.get(key) ?? [];
+
+        if (r_sort !== undefined && Object.keys(r_sort).length > 0) {
+          rows = rows.toSorted((a, b) => to_sorted(a, b, r_sort));
+        }
+
+        if (kind === "one") {
+          if (r_limit !== undefined) rows = rows.slice(0, r_limit);
+          const got = rows[0];
+          out[i][r_name] = got ? project_rel(got) : null;
+        } else {
+          if (r_limit !== undefined) rows = rows.slice(0, r_limit);
+          out[i][r_name] = rows.map(project_rel);
+        }
+      }
+    }
+
+    return out;
+  }
+
+  async update(as: As, args: { set: DataDict; where: DataDict }) {
+    assert.nonempty(args.set);
+    assert.dict(args.where);
+
+    await this.#load(as.table);
+    const table = this.#use(as.table);
+    const matched = table.filter(record => match(record, args.where));
+    const pk = as.pk;
+
+    const count = matched.map(record => {
+      const merged = { ...record, ...args.set };
+      const changed = Object.fromEntries(
+        Object.entries(merged).filter(([, value]) => !is.null(value)),
+      );
+      const index = pk !== null
+        ? table.findIndex(stored => stored[pk] === record[pk])
+        : table.findIndex(stored => stored === record);
+      table.splice(index, 1, changed);
+      return changed;
+    }).length;
+
+    if (count > 0) await this.#persist(as.table);
+
+    return count;
+  }
+
+  async delete(as: As, args: { where: DataDict }) {
+    assert.nonempty(args.where);
+
+    await this.#load(as.table);
+    const table = this.#use(as.table);
+    const size_before = table.length;
+
+    this.#tables[as.table] = table.filter(record => !match(record, args.where));
+
+    const count = size_before - this.#use(as.table).length;
+    if (count > 0) await this.#persist(as.table);
+
+    return count;
+  }
+}

--- a/packages/jsondb/src/private/typemap.ts
+++ b/packages/jsondb/src/private/typemap.ts
@@ -1,0 +1,41 @@
+import type ColumnTypes from "#ColumnTypes";
+import type { TypeMap } from "@primate/core/db";
+
+function identity<C extends keyof ColumnTypes>(column: C): {
+  bind: (value: ColumnTypes[C]) => ColumnTypes[C];
+  column: C;
+  unbind: (value: ColumnTypes[C]) => ColumnTypes[C];
+} {
+  return {
+    bind: value => value,
+    column,
+    unbind: value => value,
+  };
+}
+
+const typemap: TypeMap<ColumnTypes> = {
+  blob: identity("BLOB"),
+  boolean: identity("BOOLEAN"),
+  datetime: identity("DATE"),
+  f32: identity("NUMBER"),
+  f64: identity("NUMBER"),
+  i128: identity("BIGINT"),
+  i16: identity("NUMBER"),
+  i32: identity("NUMBER"),
+  i64: identity("BIGINT"),
+  i8: identity("NUMBER"),
+  json: identity("JSON"),
+  string: identity("STRING"),
+  time: identity("STRING"),
+  u128: identity("BIGINT"),
+  u16: identity("NUMBER"),
+  u32: identity("NUMBER"),
+  u64: identity("BIGINT"),
+  u8: identity("NUMBER"),
+  url: identity("URL"),
+  uuid: identity("STRING"),
+  uuid_v4: identity("STRING"),
+  uuid_v7: identity("STRING"),
+};
+
+export default typemap;

--- a/packages/jsondb/src/public/index.ts
+++ b/packages/jsondb/src/public/index.ts
@@ -1,3 +1,3 @@
-import JsonDB from "#JsonDB";
+import JSONDB from "#JSONDB";
 
-export default (config?: typeof JsonDB.config) => new JsonDB(config);
+export default (config?: typeof JSONDB.config) => new JSONDB(config);

--- a/packages/jsondb/src/public/index.ts
+++ b/packages/jsondb/src/public/index.ts
@@ -1,0 +1,3 @@
+import JsonDB from "#JsonDB";
+
+export default (config?: typeof JsonDB.config) => new JsonDB(config);

--- a/packages/jsondb/tsconfig.json
+++ b/packages/jsondb/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
## Summary

- Adds `@primate/jsondb`, a new database adapter that persists data to JSON files on disk
- Operates in-memory (like MemoryDB) for CRUD but writes each table as `<directory>/<table>.json`
- Handles non-JSON-native types via `__type` wrapper objects: BigInt as `{__type: "bigint", value: "string"}`, Blob as `{__type: "blob", value: "base64"}`, Date and URL similarly
- Implements the full `DB<Tables>` interface including schema management (create/delete/introspect/alter), relations (`with`), all WHERE operators, sort, limit, field projection, and auto-PK generation
- Follows the same package structure, coding style, and import patterns as `@primate/sqlite` and `@primate/postgresql`

## New files

| File | Purpose |
|------|---------|
| `packages/jsondb/package.json` | Package config, mirrors sqlite structure |
| `packages/jsondb/tsconfig.json` | Extends root tsconfig |
| `packages/jsondb/src/public/index.ts` | Public entry point |
| `packages/jsondb/src/private/JsonDB.ts` | Main implementation |
| `packages/jsondb/src/private/JsonDB.spec.ts` | Core test suite + JSON-specific tests |
| `packages/jsondb/src/private/typemap.ts` | Identity type mappings for all data types |
| `packages/jsondb/src/private/ColumnTypes.ts` | Column type definitions |

## Test plan

- [ ] `cd packages/jsondb && npm run build` compiles with no errors
- [ ] `cd packages/jsondb && npm test` — core DB test suite passes
- [ ] Custom tests verify JSON file persistence, BigInt/Blob serialization, data reload from disk, and schema.delete file cleanup
