### PR TITLE
fix(core): harden redirect handling

### DIFF
--- a/apps/js/test/redirect.spec.ts
+++ b/apps/js/test/redirect.spec.ts
@@ -1,0 +1,24 @@
+import test from "@primate/test";
+import http from "@rcompat/http";
+
+const browser = test.setup(import.meta.dirname);
+
+test.case("backend redirect responses", async assert => {
+  await using tab = await browser.open();
+
+  const redirected = await tab.fetch("/response/redirect", {
+    redirect: "manual",
+  });
+  assert(redirected.status).equals(http.Status.FOUND);
+  assert(redirected.headers.get("Location")).equals("/redirected");
+
+  const permanent = await tab.fetch("/response/redirect-status", {
+    redirect: "manual",
+  });
+  assert(permanent.status).equals(http.Status.MOVED_PERMANENTLY);
+  assert(permanent.headers.get("Location")).equals("/redirected");
+});
+
+test.ended(async () => {
+  await browser.close();
+});

--- a/apps/website/routes/chat.ts
+++ b/apps/website/routes/chat.ts
@@ -1,7 +1,10 @@
+import response from "primate/response";
 import route from "primate/route";
 
 export default route({
   get() {
-    return new URL("https://discord.gg/RSg4NNwM4f");
+    return response.redirect.external("https://discord.gg/RSg4NNwM4f", {
+      allowedOrigins: ["https://discord.gg"],
+    });
   },
 });

--- a/apps/website/snippets/guides/responses/redirect-to-login/hook/TypeScript.ts
+++ b/apps/website/snippets/guides/responses/redirect-to-login/hook/TypeScript.ts
@@ -8,5 +8,8 @@ export default route.hook((request, next) => {
     return next(request);
   }
 
-  return response.redirect(`/login?next=${request.target}`);
+  return response.redirect.local({
+    pathname: "/login",
+    query: { next: request.target },
+  });
 });

--- a/apps/website/snippets/guides/responses/redirect-to-login/login/TypeScript.ts
+++ b/apps/website/snippets/guides/responses/redirect-to-login/login/TypeScript.ts
@@ -1,3 +1,4 @@
+import Status from "@rcompat/http/Status";
 import response from "primate/response";
 import route from "primate/route";
 
@@ -8,6 +9,8 @@ export default route({
   post(request) {
     // do verification work, create session, etc.
 
-    return response.redirect(request.query.get("next"));
+    return response.redirect.local(request.query.try("next") ?? "/", {
+      status: Status.SEE_OTHER,
+    });
   },
 });

--- a/apps/website/snippets/responses/redirect/explicit/Go.go
+++ b/apps/website/snippets/responses/redirect/explicit/Go.go
@@ -6,9 +6,9 @@ import (
 )
 
 var _ = route.Get(func(_ route.Request) any {
-	return response.Redirect("https://primate.run", 303)
+	return response.Redirect("/account")
 })
 
 var _ = route.Post(func(_ route.Request) any {
-	return response.Redirect("/login")
+	return response.Redirect("/login", 303)
 })

--- a/apps/website/snippets/responses/redirect/explicit/JavaScript.ts
+++ b/apps/website/snippets/responses/redirect/explicit/JavaScript.ts
@@ -4,9 +4,15 @@ import route from "primate/route";
 
 export default route({
   get() {
-    return response.redirect("https://primate.run", Status.SEE_OTHER);
+    return response.redirect.external("https://primate.run", {
+      allowedOrigins: ["https://primate.run"],
+      status: Status.SEE_OTHER,
+    });
   },
   post(request) {
-    return response.redirect(`/login?next=${request.target}`);
+    return response.redirect.local({
+      pathname: "/login",
+      query: { next: request.target },
+    }, { status: Status.SEE_OTHER });
   },
 });

--- a/apps/website/snippets/responses/redirect/explicit/Python.py
+++ b/apps/website/snippets/responses/redirect/explicit/Python.py
@@ -3,9 +3,9 @@ from primate import Response, Route
 
 @Route.get
 def get(request):
-    return Response.redirect("https://primate.run", 303)
+    return Response.redirect("/account")
 
 
 @Route.post
 def post(request):
-    return Response.redirect("/login")
+    return Response.redirect("/login", 303)

--- a/apps/website/snippets/responses/redirect/explicit/Ruby.rb
+++ b/apps/website/snippets/responses/redirect/explicit/Ruby.rb
@@ -2,9 +2,9 @@ require 'primate/route'
 require 'primate/response'
 
 Route.get do |request|
-  Response.redirect('https://primate.run', 303)
+  Response.redirect('/account')
 end
 
 Route.post do |request|
-  Response.redirect('/login')
+  Response.redirect('/login', 303)
 end

--- a/apps/website/snippets/responses/redirect/explicit/TypeScript.ts
+++ b/apps/website/snippets/responses/redirect/explicit/TypeScript.ts
@@ -4,9 +4,15 @@ import route from "primate/route";
 
 export default route({
   get() {
-    return response.redirect("https://primate.run", Status.SEE_OTHER);
+    return response.redirect.external("https://primate.run", {
+      allowedOrigins: ["https://primate.run"],
+      status: Status.SEE_OTHER,
+    });
   },
   post(request) {
-    return response.redirect(`/login?next=${request.target}`);
+    return response.redirect.local({
+      pathname: "/login",
+      query: { next: request.target },
+    }, { status: Status.SEE_OTHER });
   },
 });

--- a/apps/website/snippets/responses/redirect/implicit/JavaScript.ts
+++ b/apps/website/snippets/responses/redirect/implicit/JavaScript.ts
@@ -1,7 +1,0 @@
-import route from "primate/route";
-
-export default route({
-  get() {
-    return new URL("https://example.com/login");
-  },
-});

--- a/apps/website/snippets/responses/redirect/implicit/TypeScript.ts
+++ b/apps/website/snippets/responses/redirect/implicit/TypeScript.ts
@@ -1,7 +1,0 @@
-import route from "primate/route";
-
-export default route({
-  get() {
-    return new URL("https://example.com/login");
-  },
-});

--- a/apps/website/snippets/responses/redirect/implicit/filename.ts
+++ b/apps/website/snippets/responses/redirect/implicit/filename.ts
@@ -1,3 +1,0 @@
-import type { FileRef } from "@rcompat/fs";
-
-export default (file: FileRef) => `routes/redirect${file.fullExtension}`;

--- a/apps/website/views/docs/docs/backend.md
+++ b/apps/website/views/docs/docs/backend.md
@@ -159,6 +159,9 @@ Redirect to other routes:
 return response.Redirect("/other-route")
 ```
 
+Binding redirects are local and origin-relative. Redirect targets and the exact
+allowed status codes are validated by the core runtime.
+
 ## Database Operations
 
 Built-in store operations:

--- a/apps/website/views/docs/docs/backend/go.md
+++ b/apps/website/views/docs/docs/backend/go.md
@@ -369,6 +369,10 @@ var _ = route.Get(func(request route.Request) any {
 })
 ```
 
+Binding redirects are local and origin-relative. The core validates the target
+at runtime and accepts only status codes `301`, `302`, `303`, `307` and `308`.
+Use `303` after handling a form submission.
+
 ### Error Responses
 
 Return error responses:

--- a/apps/website/views/docs/docs/backend/python.md
+++ b/apps/website/views/docs/docs/backend/python.md
@@ -304,6 +304,10 @@ def get(request):
     return Response.redirect("/redirected", status=301)  # moved permanently
 ```
 
+Binding redirects are local and origin-relative. The core validates the target
+at runtime and accepts only status codes `301`, `302`, `303`, `307` and `308`.
+Use `303` after handling a form submission.
+
 ### Error Responses
 
 Return error responses:

--- a/apps/website/views/docs/docs/backend/ruby.md
+++ b/apps/website/views/docs/docs/backend/ruby.md
@@ -331,6 +331,10 @@ Route.get do |request|
 end
 ```
 
+Binding redirects are local and origin-relative. The core validates the target
+at runtime and accepts only status codes `301`, `302`, `303`, `307` and `308`.
+Use `303` after handling a form submission.
+
 ### Error Responses
 
 Return error responses:

--- a/apps/website/views/docs/docs/responses.md
+++ b/apps/website/views/docs/docs/responses.md
@@ -66,13 +66,18 @@ The callable `response.redirect(...)` form remains an alias for
 Pass an object to serialize query values with `URLSearchParams` rather than
 building a nested query string manually. `false`, `0` and empty strings are
 preserved; `null` and `undefined` are omitted; arrays produce repeated keys.
-Explicit local fragments are preserved.
+Local paths use WHATWG URL serialization: Unicode is percent-encoded, valid
+existing escapes are preserved, dot segments are normalized, and a normalized
+pathname beginning with `//` is rejected. Explicit local fragments are
+preserved.
 
 Use `response.redirect.external` only when an external destination is intended.
 It requires an exact origin allowlist and accepts HTTPS destinations by default.
 Origin checks do not use substring or suffix matching. HTTP requires the
 explicit `allowHttp` development option, and URL credentials and non-HTTP
-schemes are rejected.
+schemes are rejected. If the external destination has no fragment, Primate
+emits an explicit empty fragment so the user agent cannot inherit one from the
+source URL.
 
 Only `301`, `302`, `303`, `307` and `308` are accepted. Prefer `303 See Other`
 after a form submission. `307` and `308` preserve the request method and body;

--- a/apps/website/views/docs/docs/responses.md
+++ b/apps/website/views/docs/docs/responses.md
@@ -13,7 +13,7 @@ aspects of the response.
 |`string`|[text](#text)|`200 text/plain`|Serve plain text|
 |`object`|[json](#json)|`200 application/json`|Serve JSON|
 |`Blob`·`File`·`FileRef`|[binary](#binary)|`200 application/octet-stream`|Stream contents|
-|`URL`|[redirect](#redirect)|`302`|Redirect to URL|
+|—|[redirect](#redirect)|`302`|Redirect safely|
 |—|[view](#view)|`200 text/html`|Serve frontend component|
 |—|[page](#page)|`200 text/html`|Serve collocated route page|
 |—|[error](#error)|`404 text/html`|Show error page|
@@ -57,11 +57,33 @@ Use rcompat's `FileRef` to conveniently load a file from disk and stream it out.
 [s=responses/binary/file-ref]
 
 ## Redirect
-Return a `URL` to redirect to another address.
+Use `response.redirect.local` for origin-relative redirects. Local redirects are
+safe by default: malformed paths, protocol-relative targets, backslashes,
+control characters and targets that resolve to another origin are rejected.
+The callable `response.redirect(...)` form remains an alias for
+`response.redirect.local(...)`.
 
-[s=responses/redirect/implicit]
+Pass an object to serialize query values with `URLSearchParams` rather than
+building a nested query string manually. `false`, `0` and empty strings are
+preserved; `null` and `undefined` are omitted; arrays produce repeated keys.
+Explicit local fragments are preserved.
 
-Use the explicit `redirect` handler to vary the status or for local redirects.
+Use `response.redirect.external` only when an external destination is intended.
+It requires an exact origin allowlist and accepts HTTPS destinations by default.
+Origin checks do not use substring or suffix matching. HTTP requires the
+explicit `allowHttp` development option, and URL credentials and non-HTTP
+schemes are rejected.
+
+Only `301`, `302`, `303`, `307` and `308` are accepted. Prefer `303 See Other`
+after a form submission. `307` and `308` preserve the request method and body;
+external redirects using either status also require `preserveMethod: true`.
+Both local and external redirects enforce a 2048-byte `Location` limit by
+default, configurable with `maxLocationBytes`.
+
+Returning a `URL` no longer creates an implicit redirect. Migrate those routes
+to `response.redirect.external` with an explicit `allowedOrigins` policy.
+Never pass untrusted request or query input to an unrestricted external
+redirect.
 
 [s=responses/redirect/explicit]
 

--- a/apps/website/views/docs/guides/responses/redirect-to-login.md
+++ b/apps/website/views/docs/guides/responses/redirect-to-login.md
@@ -4,7 +4,9 @@ title: Redirect to login page
 
 To conditionally redirect to a login page based on session status, create a
 hook file inside `routes` and check if the user has a valid session. If not,
-redirect to `/login` with `request.target` (pathname and query string).
+redirect locally to `/login` and pass `request.target` as a structured `next`
+query value. Structured serialization prevents characters in the target from
+changing the surrounding login URL.
 
 !!!
 A hook file inside the top `routes` directory applies to all routes of your
@@ -16,7 +18,11 @@ subdirectory.
 
 ---
 
-Inside your `/login` route, read the `next` query parameter to redirect back to
-the page the user came from.
+Inside your `/login` route, read the `next` query parameter and pass it to the
+local redirect helper. The helper rejects absolute, protocol-relative and
+malformed targets, so attacker-controlled input cannot redirect to another
+origin. After a successful login form submission, use `303 See Other` to switch
+the follow-up request to `GET`; `307` and `308` would preserve the form method
+and body.
 
 [s=guides/responses/redirect-to-login/login]

--- a/packages/core/src/private/client/transport.spec.ts
+++ b/packages/core/src/private/client/transport.spec.ts
@@ -70,20 +70,57 @@ test.case("client refuses cross-origin manual redirect hops", async assert => {
   });
 });
 
-test.case("client rejects malformed Location values predictably", async assert => {
+test.case("client parses Location only for redirect statuses", async assert => {
+  await withBrowser(
+    async () => new Response("ok", {
+      headers: { Location: "http://[" },
+      status: 200,
+    }),
+    async () => {
+      const result = await transport.refetch("/start");
+      assert(await result.response.text()).equals("ok");
+    },
+  );
+
   await withBrowser(
     async () => redirectResponse(302, "http://["),
     async () => {
-      let rejected = false;
+      let message = "";
       try {
         await transport.refetch("/start");
       } catch (error) {
-        rejected = error instanceof TypeError;
+        if (error instanceof TypeError) message = error.message;
       }
-      assert(rejected).true();
+      assert(message).equals("Invalid redirect Location");
     },
   );
 });
+
+test.case(
+  "client constrains non-GET redirect following to same origin",
+  async assert => {
+    let seen: RequestInit | undefined;
+    await withBrowser(async (_input, init) => {
+      seen = init;
+      const response = new Response("ok");
+      Object.defineProperty(response, "url", {
+        value: "https://app.example/done",
+      });
+      return response;
+    }, async () => {
+      const result = await transport.refetch("/start", {
+        body: "secret=form-value",
+        method: "POST",
+        mode: "cors",
+      });
+      assert(seen?.method).equals("POST");
+      assert(seen?.body).equals("secret=form-value");
+      assert(seen?.mode).equals("same-origin");
+      assert(seen?.redirect).equals("follow");
+      assert(result.requested.pathname).equals("/done");
+    });
+  },
+);
 
 test.case("client enforces redirect hop limits", async assert => {
   let calls = 0;

--- a/packages/core/src/private/client/transport.spec.ts
+++ b/packages/core/src/private/client/transport.spec.ts
@@ -1,0 +1,103 @@
+import transport from "#client/transport";
+import test from "@rcompat/test";
+
+const location = new URL("https://app.example/current");
+
+async function withBrowser(
+  fetcher: typeof fetch,
+  run: () => Promise<void>,
+) {
+  const originalFetch = globalThis.fetch;
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "location");
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: location,
+  });
+  globalThis.fetch = fetcher;
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (descriptor === undefined) {
+      delete (globalThis as any).location;
+    } else {
+      Object.defineProperty(globalThis, "location", descriptor);
+    }
+  }
+}
+
+function redirectResponse(status: number, target: string) {
+  return new Response(null, { headers: { Location: target }, status });
+}
+
+test.case("client follows only exact redirect statuses", async assert => {
+  for (const status of [301, 302, 303, 307, 308]) {
+    const paths: string[] = [];
+    await withBrowser(async input => {
+      paths.push(String(input));
+      return paths.length === 1
+        ? redirectResponse(status, "/next")
+        : new Response("ok");
+    }, async () => {
+      const result = await transport.refetch("/start");
+      assert(result.requested.pathname).equals("/next");
+      assert(paths).equals(["/start", "/next"]);
+    });
+  }
+
+  for (const status of [300, 304, 305, 306, 309, 399]) {
+    const paths: string[] = [];
+    await withBrowser(async input => {
+      paths.push(String(input));
+      return redirectResponse(status, "/next");
+    }, async () => {
+      const result = await transport.refetch("/start");
+      assert(result.requested.pathname).equals("/start");
+      assert(paths).equals(["/start"]);
+    });
+  }
+});
+
+test.case("client refuses cross-origin manual redirect hops", async assert => {
+  const paths: string[] = [];
+  await withBrowser(async input => {
+    paths.push(String(input));
+    return redirectResponse(302, "https://evil.example/next");
+  }, async () => {
+    const result = await transport.refetch("/start");
+    assert(result.requested.pathname).equals("/start");
+    assert(paths).equals(["/start"]);
+  });
+});
+
+test.case("client rejects malformed Location values predictably", async assert => {
+  await withBrowser(
+    async () => redirectResponse(302, "http://["),
+    async () => {
+      let rejected = false;
+      try {
+        await transport.refetch("/start");
+      } catch (error) {
+        rejected = error instanceof TypeError;
+      }
+      assert(rejected).true();
+    },
+  );
+});
+
+test.case("client enforces redirect hop limits", async assert => {
+  let calls = 0;
+  await withBrowser(async () => {
+    calls++;
+    return redirectResponse(302, `/hop-${calls}`);
+  }, async () => {
+    let message = "";
+    try {
+      await transport.refetch("/start", {}, 2);
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    assert(message).equals("Too many redirects");
+    assert(calls).equals(2);
+  });
+});

--- a/packages/core/src/private/client/transport.ts
+++ b/packages/core/src/private/client/transport.ts
@@ -6,7 +6,12 @@ const sameorigin = (url: URL) => url.origin === globalThis.location.origin;
 const get_location = (response: Response, base: string) => {
   if (response.type === "opaqueredirect") return null;
   const location = response.headers.get("Location");
-  return location !== null ? new URL(location, base) : null;
+  if (location === null) return null;
+  try {
+    return new URL(location, base);
+  } catch {
+    throw new TypeError("Invalid redirect Location");
+  }
 };
 
 async function refetch(
@@ -20,8 +25,12 @@ async function refetch(
   let hops = 0;
 
   if (method !== "GET") {
+    // Fetch may replay a body for 307/308, so prevent automatic redirect
+    // following from ever leaving the browser's current origin.
     const response = await fetch(url.pathname + url.search, {
-      ...init, redirect: "follow",
+      ...init,
+      mode: "same-origin",
+      redirect: "follow",
     });
     return { requested: new URL(response.url), response };
   }
@@ -33,12 +42,14 @@ async function refetch(
 
     if (response.type === "opaqueredirect") return { requested: url, response };
 
-    const location = get_location(response, url.toString());
-    if (location !== null && isRedirectStatus(response.status)) {
-      if (!sameorigin(location)) return { requested: url, response };
-      url = location;
-      hops++;
-      continue;
+    if (isRedirectStatus(response.status)) {
+      const location = get_location(response, url.toString());
+      if (location !== null) {
+        if (!sameorigin(location)) return { requested: url, response };
+        url = location;
+        hops++;
+        continue;
+      }
     }
 
     return { requested: url, response };

--- a/packages/core/src/private/client/transport.ts
+++ b/packages/core/src/private/client/transport.ts
@@ -1,3 +1,4 @@
+import { isRedirectStatus } from "#response/redirect-status";
 import http from "@rcompat/http";
 
 const sameorigin = (url: URL) => url.origin === globalThis.location.origin;
@@ -33,7 +34,7 @@ async function refetch(
     if (response.type === "opaqueredirect") return { requested: url, response };
 
     const location = get_location(response, url.toString());
-    if (location !== null && response.status >= 300 && response.status < 400) {
+    if (location !== null && isRedirectStatus(response.status)) {
       if (!sameorigin(location)) return { requested: url, response };
       url = location;
       hops++;

--- a/packages/core/src/private/errors.ts
+++ b/packages/core/src/private/errors.ts
@@ -141,6 +141,9 @@ const REQUEST = error.coded({
 function response_invalid_body(body: string) {
   return t`invalid body ${body} returned from route`;
 }
+function response_implicit_url() {
+  return t`implicit URL redirects are disabled; use response.redirect.external`;
+}
 function response_page_context_missing() {
   return t`${"response.page"} requires a route context`;
 }
@@ -150,6 +153,7 @@ function response_page_missing(route: string) {
 
 const RESPONSE = error.coded({
   response_invalid_body,
+  response_implicit_url,
   response_page_context_missing,
   response_page_missing,
 });

--- a/packages/core/src/private/response.client.ts
+++ b/packages/core/src/private/response.client.ts
@@ -2,11 +2,19 @@ function server_only(name: string): never {
   throw new Error(`response.${name}() is server-only`);
 }
 
+const redirect = Object.assign(
+  () => server_only("redirect"),
+  {
+    external: () => server_only("redirect.external"),
+    local: () => server_only("redirect.local"),
+  },
+);
+
 export default {
   binary: () => server_only("binary"),
   error: () => server_only("error"),
   json: () => server_only("json"),
-  redirect: () => server_only("redirect"),
+  redirect,
   sse: () => server_only("sse"),
   text: () => server_only("text"),
   view: () => server_only("view"),

--- a/packages/core/src/private/response.client.ts
+++ b/packages/core/src/private/response.client.ts
@@ -1,3 +1,5 @@
+import type serverRedirect from "#response/redirect";
+
 function server_only(name: string): never {
   throw new Error(`response.${name}() is server-only`);
 }
@@ -8,7 +10,7 @@ const redirect = Object.assign(
     external: () => server_only("redirect.external"),
     local: () => server_only("redirect.local"),
   },
-);
+) as typeof serverRedirect;
 
 export default {
   binary: () => server_only("binary"),

--- a/packages/core/src/private/response/ResponseLike.ts
+++ b/packages/core/src/private/response/ResponseLike.ts
@@ -8,7 +8,6 @@ type ResponseLike =
   | string
   | Dict
   | Dict[]
-  | URL
   | Blob
   | ReadableStream
   | Streamable

--- a/packages/core/src/private/response/redirect-status.ts
+++ b/packages/core/src/private/response/redirect-status.ts
@@ -1,0 +1,7 @@
+export type RedirectStatus = 301 | 302 | 303 | 307 | 308;
+
+const statuses = new Set<number>([301, 302, 303, 307, 308]);
+
+export function isRedirectStatus(status: number): status is RedirectStatus {
+  return statuses.has(status);
+}

--- a/packages/core/src/private/response/redirect.spec.ts
+++ b/packages/core/src/private/response/redirect.spec.ts
@@ -21,6 +21,14 @@ function rejects(assert: any, create: () => unknown) {
   assert(create).throws(Error);
 }
 
+function hasForbiddenControl(value: string) {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
 test.case("redirect.local accepts origin-relative targets", assert => {
   const cases = [
     ["/", "/"],
@@ -204,7 +212,7 @@ test.case("accepted local redirects preserve origin invariants", assert => {
           assert(emitted.startsWith("/")).true();
           assert(emitted.startsWith("//")).false();
           assert(emitted.includes("\\")).false();
-          assert(/[\u0000-\u001f\u007f]/u.test(emitted)).false();
+          assert(hasForbiddenControl(emitted)).false();
           assert(new TextEncoder().encode(emitted).byteLength <= 2048).true();
         } catch {
           // Rejection is valid; the property applies to every accepted target.

--- a/packages/core/src/private/response/redirect.spec.ts
+++ b/packages/core/src/private/response/redirect.spec.ts
@@ -1,0 +1,217 @@
+import redirect from "#response/redirect";
+import test from "@rcompat/test";
+
+const app = {
+  respond(body: BodyInit | null, init?: ResponseInit) {
+    return new Response(body, init);
+  },
+};
+
+const requestURL = "https://app.example/current?from=test";
+
+function render(handler: any, url = requestURL): Response {
+  return handler(app, {}, { url: new URL(url) }) as Response;
+}
+
+function location(handler: any, url = requestURL): string {
+  return render(handler, url).headers.get("Location")!;
+}
+
+function rejects(assert: any, create: () => unknown) {
+  assert(create).throws(Error);
+}
+
+test.case("redirect.local accepts origin-relative targets", assert => {
+  const cases = [
+    ["/", "/"],
+    ["/account", "/account"],
+    ["/account/profile", "/account/profile"],
+    ["/account?tab=security", "/account?tab=security"],
+    ["/account#sessions", "/account#sessions"],
+    ["/a%20b", "/a%20b"],
+    ["/café?term=✓", "/caf%C3%A9?term=%E2%9C%93"],
+  ];
+
+  for (const [target, expected] of cases) {
+    assert(location((redirect as any).local(target))).equals(expected);
+  }
+});
+
+test.case("redirect callable remains a local-safe compatibility alias", assert => {
+  assert(location((redirect as any)("/account", 303))).equals("/account");
+  assert(render((redirect as any)("/account", 303)).status).equals(303);
+  rejects(assert, () => (redirect as any)("https://evil.example"));
+});
+
+test.case("redirect.local rejects malformed and ambiguous targets", assert => {
+  const targets = [
+    "//evil.example",
+    "///evil.example",
+    "/\\evil.example",
+    "/\\\\evil.example",
+    "/%5cevil.example",
+    "/%5Cevil.example",
+    "/..//evil.example",
+    "/%2e%2e//evil.example",
+    "/%2E%2E//evil.example",
+    "https://evil.example",
+    "http://evil.example",
+    "https://app.example@evil.example",
+    "javascript:alert(1)",
+    "data:text/html,test",
+    "file:///tmp/test",
+    " leading-space",
+    "/trailing-space ",
+    "/embedded\rreturn",
+    "/embedded\nnewline",
+    "/embedded\0nul",
+  ];
+
+  for (const target of targets) {
+    rejects(assert, () => (redirect as any).local(target));
+  }
+});
+
+test.case("redirect.local serializes structured query values", assert => {
+  const emitted = location((redirect as any).local({
+    pathname: "/検索",
+    query: {
+      amp: "&",
+      equals: "=",
+      question: "?",
+      hash: "#",
+      percent: "%",
+      space: "a b",
+      unicode: "✓",
+      false: false,
+      zero: 0,
+      empty: "",
+      nullish: null,
+      missing: undefined,
+      repeated: ["one", "two&", null, undefined, 0, false],
+    },
+    hash: "結果",
+  }));
+
+  assert(emitted).equals(
+    "/%E6%A4%9C%E7%B4%A2?amp=%26&equals=%3D&question=%3F&hash=%23&percent=%25&space=a+b&unicode=%E2%9C%93&false=false&zero=0&empty=&repeated=one&repeated=two%26&repeated=0&repeated=false#%E7%B5%90%E6%9E%9C",
+  );
+});
+
+test.case("redirect.local validates status codes at runtime", assert => {
+  for (const status of [301, 302, 303, 307, 308]) {
+    assert(render((redirect as any).local("/ok", { status })).status).equals(status);
+  }
+  for (const status of [300, 304, 305, 306, 309, 399, 200]) {
+    rejects(assert, () => (redirect as any).local("/no", { status }));
+  }
+});
+
+test.case("redirect.local enforces serialized Location byte limits", assert => {
+  const target = { pathname: "/é" };
+  assert(location((redirect as any).local(target, { maxLocationBytes: 7 })))
+    .equals("/%C3%A9");
+  rejects(assert, () => (redirect as any).local(target, { maxLocationBytes: 6 }));
+});
+
+test.case("redirect headers cannot override validated Location", assert => {
+  const response = render((redirect as any).local("/safe", {
+    headers: {
+      "Cache-Control": "private",
+      "Content-Length": "123",
+      Location: "//evil.example",
+      "X-Test": "present",
+    },
+  }));
+
+  assert(response.headers.get("Location")).equals("/safe");
+  assert(response.headers.get("Content-Length")).equals("0");
+  assert(response.headers.get("Cache-Control")).equals("private");
+  assert(response.headers.get("X-Test")).equals("present");
+
+  const defaults = render((redirect as any).local("/safe"));
+  assert(defaults.headers.get("Cache-Control")).equals("no-cache");
+});
+
+test.case("redirect.external requires exact authorized HTTP origins", assert => {
+  const external = (redirect as any).external;
+  const allowedOrigins = ["https://trusted.example"];
+
+  assert(location(external("https://trusted.example/path?x=1#done", {
+    allowedOrigins,
+  }))).equals("https://trusted.example/path?x=1#done");
+  assert(location(external("https://trusted.example/path", {
+    allowedOrigins,
+  }))).equals("https://trusted.example/path#");
+
+  for (const target of [
+    "https://sub.trusted.example/path",
+    "https://trusted.example.evil/path",
+    "https://eviltrusted.example/path",
+    "https://user:secret@trusted.example/path",
+    "https://user@trusted.example/path",
+    "http://trusted.example/path",
+    "javascript:alert(1)",
+    "data:text/html,test",
+    "file:///tmp/test",
+    "blob:https://trusted.example/id",
+    "ftp://trusted.example/file",
+    "mailto:user@trusted.example",
+    "https://unlisted.example/path",
+  ]) {
+    rejects(assert, () => external(target, { allowedOrigins }));
+  }
+});
+
+test.case("redirect.external makes HTTP and method preservation explicit", assert => {
+  const external = (redirect as any).external;
+
+  assert(location(external("http://localhost:3000/dev", {
+    allowedOrigins: ["http://localhost:3000"],
+    allowHttp: true,
+  }))).equals("http://localhost:3000/dev#");
+
+  for (const status of [307, 308]) {
+    rejects(assert, () => render(external("https://trusted.example/post", {
+      allowedOrigins: ["https://trusted.example"],
+      status,
+    })));
+
+    assert(render(external("https://trusted.example/post", {
+      allowedOrigins: ["https://trusted.example"],
+      preserveMethod: true,
+      status,
+    })).status).equals(status);
+  }
+});
+
+test.case("accepted local redirects preserve origin invariants", assert => {
+  const parts = [
+    "", "a", ".", "..", "%2e", "%2E", "%2f", "%5c", "\\", "✓",
+    "?x=&y=%", "#fragment", "\r", "\n", "\0",
+  ];
+  const prefixes = ["/", "//", "/a/", "/../", "/%2e%2e/"];
+  let accepted = 0;
+
+  for (const prefix of prefixes) {
+    for (const first of parts) {
+      for (const second of parts.slice(0, 8)) {
+        try {
+          const response = render((redirect as any).local(prefix + first + second));
+          const emitted = response.headers.get("Location")!;
+          accepted++;
+          assert(new URL(emitted, requestURL).origin).equals(new URL(requestURL).origin);
+          assert(emitted.startsWith("/")).true();
+          assert(emitted.startsWith("//")).false();
+          assert(emitted.includes("\\")).false();
+          assert(/[\u0000-\u001f\u007f]/u.test(emitted)).false();
+          assert(new TextEncoder().encode(emitted).byteLength <= 2048).true();
+        } catch {
+          // Rejection is valid; the property applies to every accepted target.
+        }
+      }
+    }
+  }
+
+  assert(accepted > 0).true();
+});

--- a/packages/core/src/private/response/redirect.spec.ts
+++ b/packages/core/src/private/response/redirect.spec.ts
@@ -21,6 +21,14 @@ function rejects(assert: any, create: () => unknown) {
   assert(create).throws(Error);
 }
 
+function errorCode(create: () => unknown) {
+  try {
+    create();
+  } catch (error) {
+    return (error as { code?: string }).code;
+  }
+}
+
 function hasForbiddenControl(value: string) {
   for (const character of value) {
     const code = character.charCodeAt(0);
@@ -35,7 +43,9 @@ test.case("redirect.local accepts origin-relative targets", assert => {
     ["/account", "/account"],
     ["/account/profile", "/account/profile"],
     ["/account?tab=security", "/account?tab=security"],
+    ["/account?", "/account?"],
     ["/account#sessions", "/account#sessions"],
+    ["/account#", "/account#"],
     ["/a%20b", "/a%20b"],
     ["/café?term=✓", "/caf%C3%A9?term=%E2%9C%93"],
   ];
@@ -80,6 +90,26 @@ test.case("redirect.local rejects malformed and ambiguous targets", assert => {
   }
 });
 
+test.case("redirect.local rejects non-plain structured targets", assert => {
+  class Target {
+    pathname = "/safe";
+  }
+
+  assert(location((redirect as any).local({
+    pathname: "/safe",
+    metadata: "ignored",
+  }))).equals("/safe");
+
+  for (const target of [
+    new Target(),
+    new URL("https://evil.example/safe"),
+    { pathname: "/safe", href: "https://evil.example/safe" },
+    { pathname: "/safe", query: new URLSearchParams("next=/account") },
+  ]) {
+    rejects(assert, () => (redirect as any).local(target));
+  }
+});
+
 test.case("redirect.local serializes structured query values", assert => {
   const emitted = location((redirect as any).local({
     pathname: "/検索",
@@ -104,13 +134,19 @@ test.case("redirect.local serializes structured query values", assert => {
   assert(emitted).equals(
     "/%E6%A4%9C%E7%B4%A2?amp=%26&equals=%3D&question=%3F&hash=%23&percent=%25&space=a+b&unicode=%E2%9C%93&false=false&zero=0&empty=&repeated=one&repeated=two%26&repeated=0&repeated=false#%E7%B5%90%E6%9E%9C",
   );
+  assert(location((redirect as any).local({
+    pathname: "/account",
+    hash: "",
+  }))).equals("/account#");
 });
 
 test.case("redirect.local validates status codes at runtime", assert => {
   for (const status of [301, 302, 303, 307, 308]) {
     assert(render((redirect as any).local("/ok", { status })).status).equals(status);
   }
-  for (const status of [300, 304, 305, 306, 309, 399, 200]) {
+  for (const status of [
+    null, "302", NaN, 200, 300, 304, 305, 306, 309, 399,
+  ]) {
     rejects(assert, () => (redirect as any).local("/no", { status }));
   }
 });
@@ -137,6 +173,17 @@ test.case("redirect headers cannot override validated Location", assert => {
   assert(response.headers.get("Cache-Control")).equals("private");
   assert(response.headers.get("X-Test")).equals("present");
 
+  const cookies = render((redirect as any).local("/safe", {
+    headers: [
+      ["Set-Cookie", "first=1; Path=/"],
+      ["Set-Cookie", "second=2; Path=/"],
+    ],
+  })).headers.getSetCookie();
+  assert(cookies).equals([
+    "first=1; Path=/",
+    "second=2; Path=/",
+  ]);
+
   const defaults = render((redirect as any).local("/safe"));
   assert(defaults.headers.get("Cache-Control")).equals("no-cache");
 });
@@ -152,46 +199,78 @@ test.case("redirect.external requires exact authorized HTTP origins", assert => 
     allowedOrigins,
   }))).equals("https://trusted.example/path#");
 
+  assert(errorCode(() => external(
+    "https://user:secret@trusted.example/path",
+    { allowedOrigins },
+  ))).equals("credentials_not_allowed");
+
   for (const target of [
     "https://sub.trusted.example/path",
     "https://trusted.example.evil/path",
     "https://eviltrusted.example/path",
     "https://user:secret@trusted.example/path",
     "https://user@trusted.example/path",
+    "https://@trusted.example/path",
+    "https://:@trusted.example/path",
     "http://trusted.example/path",
+    "https:///trusted.example/path",
+    "https:////trusted.example/path",
     "javascript:alert(1)",
     "data:text/html,test",
     "file:///tmp/test",
     "blob:https://trusted.example/id",
     "ftp://trusted.example/file",
     "mailto:user@trusted.example",
+    "https://trusted.example/%",
+    "https://trusted.example/?next=%",
     "https://unlisted.example/path",
   ]) {
     rejects(assert, () => external(target, { allowedOrigins }));
   }
-});
 
-test.case("redirect.external makes HTTP and method preservation explicit", assert => {
-  const external = (redirect as any).external;
+  const sparse: string[] = [];
+  sparse.length = 1;
+  rejects(assert, () => external("https://trusted.example/path", {
+    allowedOrigins: sparse,
+  }));
 
-  assert(location(external("http://localhost:3000/dev", {
-    allowedOrigins: ["http://localhost:3000"],
-    allowHttp: true,
-  }))).equals("http://localhost:3000/dev#");
-
-  for (const status of [307, 308]) {
-    rejects(assert, () => render(external("https://trusted.example/post", {
-      allowedOrigins: ["https://trusted.example"],
-      status,
-    })));
-
-    assert(render(external("https://trusted.example/post", {
-      allowedOrigins: ["https://trusted.example"],
-      preserveMethod: true,
-      status,
-    })).status).equals(status);
+  for (const origin of [
+    "https://trusted.example/path",
+    "https://trusted.example?",
+    "https://trusted.example#",
+    "https://@trusted.example",
+    "https://trusted%.example",
+  ]) {
+    rejects(assert, () => external("https://trusted.example/path", {
+      allowedOrigins: [origin],
+    }));
   }
 });
+
+test.case(
+  "redirect.external makes HTTP and method preservation explicit",
+  assert => {
+    const external = (redirect as any).external;
+
+    assert(location(external("http://localhost:3000/dev", {
+      allowedOrigins: ["http://localhost:3000"],
+      allowHttp: true,
+    }))).equals("http://localhost:3000/dev#");
+
+    for (const status of [307, 308]) {
+      rejects(assert, () => render(external("https://trusted.example/post", {
+        allowedOrigins: ["https://trusted.example"],
+        status,
+      })));
+
+      assert(render(external("https://trusted.example/post", {
+        allowedOrigins: ["https://trusted.example"],
+        preserveMethod: true,
+        status,
+      })).status).equals(status);
+    }
+  },
+);
 
 test.case("accepted local redirects preserve origin invariants", assert => {
   const parts = [

--- a/packages/core/src/private/response/redirect.spec.ts
+++ b/packages/core/src/private/response/redirect.spec.ts
@@ -204,19 +204,25 @@ test.case("accepted local redirects preserve origin invariants", assert => {
   for (const prefix of prefixes) {
     for (const first of parts) {
       for (const second of parts.slice(0, 8)) {
+        let emitted: string;
         try {
-          const response = render((redirect as any).local(prefix + first + second));
-          const emitted = response.headers.get("Location")!;
-          accepted++;
-          assert(new URL(emitted, requestURL).origin).equals(new URL(requestURL).origin);
-          assert(emitted.startsWith("/")).true();
-          assert(emitted.startsWith("//")).false();
-          assert(emitted.includes("\\")).false();
-          assert(hasForbiddenControl(emitted)).false();
-          assert(new TextEncoder().encode(emitted).byteLength <= 2048).true();
+          const response = render((redirect as any).local(
+            prefix + first + second,
+          ));
+          emitted = response.headers.get("Location")!;
         } catch {
           // Rejection is valid; the property applies to every accepted target.
+          continue;
         }
+
+        accepted++;
+        assert(new URL(emitted, requestURL).origin)
+          .equals(new URL(requestURL).origin);
+        assert(emitted.startsWith("/")).true();
+        assert(emitted.startsWith("//")).false();
+        assert(emitted.includes("\\")).false();
+        assert(hasForbiddenControl(emitted)).false();
+        assert(new TextEncoder().encode(emitted).byteLength <= 2048).true();
       }
     }
   }

--- a/packages/core/src/private/response/redirect.ts
+++ b/packages/core/src/private/response/redirect.ts
@@ -7,9 +7,14 @@ import {
 const DEFAULT_MAX_LOCATION_BYTES = 2048;
 const LOCAL_BASE = new URL("https://primate.invalid/");
 const METHOD_PRESERVING_STATUSES = new Set<RedirectStatus>([307, 308]);
+const URL_LIKE_TARGET_KEYS = new Set([
+  "host", "hostname", "href", "origin", "password", "port", "protocol",
+  "username",
+]);
 const INVALID_PERCENT_ESCAPE = /%(?![\da-f]{2})/iu;
 const ENCODED_PATH_CONTROL = /%(?:0[\da-f]|1[\da-f]|7f)/iu;
 const ENCODED_BACKSLASH = /%5c/iu;
+const ABSOLUTE_URL_FORM = /^[a-z][a-z\d+.-]*:\/\/[^/?#]+(?:[/?#]|$)/iu;
 const ORIGIN_FORM = /^[a-z][a-z\d+.-]*:\/\/[^/?#]+\/?$/iu;
 
 type RedirectQueryValue = boolean | null | number | string | undefined;
@@ -96,6 +101,16 @@ function locationBytes(location: string) {
   return new TextEncoder().encode(location).byteLength;
 }
 
+function hasUserInfo(value: string) {
+  const authorityStart = value.indexOf("://") + 3;
+  if (authorityStart < 3) return false;
+  const authorityEnd = ["/", "?", "#"]
+    .map(separator => value.indexOf(separator, authorityStart))
+    .filter(index => index !== -1)
+    .reduce((first, index) => Math.min(first, index), value.length);
+  return value.slice(authorityStart, authorityEnd).includes("@");
+}
+
 function maxLocationBytes(value: unknown): number {
   const maximum = value === undefined ? DEFAULT_MAX_LOCATION_BYTES : value;
   if (
@@ -109,7 +124,7 @@ function maxLocationBytes(value: unknown): number {
 }
 
 function status(value: unknown): RedirectStatus {
-  const redirectStatus = value ?? 302;
+  const redirectStatus = value === undefined ? 302 : value;
   if (!isRedirectStatus(redirectStatus as number)) {
     fail("invalid_redirect_status");
   }
@@ -123,6 +138,14 @@ function normalizeInit(value: unknown): RedirectInit {
     fail("invalid_redirect_status");
   }
   return value as RedirectInit;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function checkRawLocalTarget(target: string) {
@@ -176,9 +199,7 @@ function checkSerializedLocal(
 
 function appendQuery(url: URL, query: unknown) {
   if (query === undefined) return;
-  if (query === null || typeof query !== "object" || Array.isArray(query)) {
-    fail("invalid_local_target");
-  }
+  if (!isPlainRecord(query)) fail("invalid_local_target");
 
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(query)) {
@@ -208,13 +229,11 @@ function serializeLocal(target: unknown, maximum: number) {
     }
   } else {
     if (
-      target === null
-      || target instanceof URL
-      || typeof target !== "object"
-      || !("pathname" in target)
+      !isPlainRecord(target)
       || typeof target.pathname !== "string"
       || target.pathname.includes("?")
       || target.pathname.includes("#")
+      || Object.keys(target).some(key => URL_LIKE_TARGET_KEYS.has(key))
     ) {
       fail("invalid_local_target");
     }
@@ -243,7 +262,7 @@ function serializeLocal(target: unknown, maximum: number) {
     }
   }
 
-  const location = url.pathname + url.search + url.hash;
+  const location = url.href.slice(url.origin.length);
   checkSerializedLocal(location, LOCAL_BASE, maximum);
   return location;
 }
@@ -259,10 +278,20 @@ function response(
     headers.set("Content-Length", "0");
     if (!headers.has("Cache-Control")) headers.set("Cache-Control", "no-cache");
 
-    return app.respond(null, {
+    const setCookies = headers.getSetCookie();
+    const result = app.respond(null, {
       headers: Object.fromEntries(headers),
       status: redirectStatus,
     });
+
+    // Object.fromEntries cannot represent repeated Set-Cookie fields.
+    if (setCookies.length > 0) {
+      result.headers.delete("Set-Cookie");
+      for (const cookie of setCookies) {
+        result.headers.append("Set-Cookie", cookie);
+      }
+    }
+    return result;
   };
 }
 
@@ -288,6 +317,7 @@ function parseExternalOrigin(origin: unknown, allowHttp: boolean) {
     || origin.trim() !== origin
     || hasForbiddenControl(origin)
     || origin.includes("\\")
+    || INVALID_PERCENT_ESCAPE.test(origin)
     || !ORIGIN_FORM.test(origin)
   ) {
     fail("invalid_external_target");
@@ -303,7 +333,9 @@ function parseExternalOrigin(origin: unknown, allowHttp: boolean) {
   const allowedProtocol = url.protocol === "https:"
     || allowHttp && url.protocol === "http:";
   if (!allowedProtocol) fail("external_scheme_not_allowed");
-  if (url.username !== "" || url.password !== "") fail("credentials_not_allowed");
+  if (hasUserInfo(origin) || url.username !== "" || url.password !== "") {
+    fail("credentials_not_allowed");
+  }
   if (url.pathname !== "/" || url.search !== "" || url.hash !== "") {
     fail("invalid_external_target");
   }
@@ -317,6 +349,8 @@ function serializeExternal(target: unknown, options: ExternalRedirectInit) {
     || raw.trim() !== raw
     || hasForbiddenControl(raw)
     || raw.includes("\\")
+    || INVALID_PERCENT_ESCAPE.test(raw)
+    || !ABSOLUTE_URL_FORM.test(raw)
   ) {
     fail("invalid_external_target");
   }
@@ -332,13 +366,20 @@ function serializeExternal(target: unknown, options: ExternalRedirectInit) {
   const allowedProtocol = url.protocol === "https:"
     || allowHttp && url.protocol === "http:";
   if (!allowedProtocol) fail("external_scheme_not_allowed");
-  if (url.username !== "" || url.password !== "") fail("credentials_not_allowed");
-  if (!Array.isArray(options.allowedOrigins) || options.allowedOrigins.length === 0) {
+  if (hasUserInfo(raw) || url.username !== "" || url.password !== "") {
+    fail("credentials_not_allowed");
+  }
+  if (
+    !Array.isArray(options.allowedOrigins)
+    || options.allowedOrigins.length === 0
+  ) {
     fail("external_origin_not_allowed");
   }
 
-  const origins = new Set(options.allowedOrigins
-    .map(origin => parseExternalOrigin(origin, allowHttp)));
+  const origins = new Set<string>();
+  for (const origin of options.allowedOrigins) {
+    origins.add(parseExternalOrigin(origin, allowHttp));
+  }
   if (!origins.has(url.origin)) fail("external_origin_not_allowed");
 
   // An explicit empty fragment prevents user agents from inheriting a source
@@ -353,7 +394,11 @@ function serializeExternal(target: unknown, options: ExternalRedirectInit) {
 }
 
 const external = ((target: unknown, options: unknown) => {
-  if (options === null || typeof options !== "object" || Array.isArray(options)) {
+  if (
+    options === null
+    || typeof options !== "object"
+    || Array.isArray(options)
+  ) {
     fail("external_origin_not_allowed");
   }
   const normalized = options as ExternalRedirectInit;

--- a/packages/core/src/private/response/redirect.ts
+++ b/packages/core/src/private/response/redirect.ts
@@ -1,109 +1,382 @@
 import type ResponseFunction from "#response/ResponseFunction";
-import http from "@rcompat/http";
-import is from "@rcompat/is";
-import type { Dict } from "@rcompat/type";
+import {
+  isRedirectStatus,
+  type RedirectStatus,
+} from "#response/redirect-status";
 
-type Redirection =
-  | 300 // MULTIPLE_CHOICES
-  | 301 // MOVED_PERMANENTLY
-  | 302 // FOUND
-  | 303 // SEE_OTHER
-  | 304 // NOT_MODIFIED
-  // 305 USE_PROXY (deprecated)
-  // 306 SWITCH_PROXY (reserved)
-  | 307 // TEMPORARY_REDIRECT
-  | 308 // PERMANENT_REDIRECT
-  ;
+const DEFAULT_MAX_LOCATION_BYTES = 2048;
+const LOCAL_BASE = new URL("https://primate.invalid/");
+const METHOD_PRESERVING_STATUSES = new Set<RedirectStatus>([307, 308]);
+const INVALID_PERCENT_ESCAPE = /%(?![\da-f]{2})/iu;
+const ENCODED_PATH_CONTROL = /%(?:0[\da-f]|1[\da-f]|7f)/iu;
+const ENCODED_BACKSLASH = /%5c/iu;
+const ORIGIN_FORM = /^[a-z][a-z\d+.-]*:\/\/[^/?#]+\/?$/iu;
 
-type RedirectObject = {
-  // must start with "/"
+type RedirectQueryValue = boolean | null | number | string | undefined;
+
+type LocalRedirectTarget = {
   pathname: string;
-  query?: Dict<boolean | null | number | string | undefined>;
-};
-
-type RedirectTarget = RedirectObject | string;
-
-type RedirectOptions = {
-  // allow absolute external redirects. Default: false (same-origin only)
-  allowExternal?: boolean;
-  // base URL used to normalize relative paths & compare origins, default `request.url`
-  base?: string | URL;
-  // max allowed Location header size (bytes), default 2048
-  maxLocationBytes?: number;
+  query?: Readonly<Record<
+    string,
+    RedirectQueryValue | readonly RedirectQueryValue[]
+  >>;
+  hash?: string;
 };
 
 type RedirectInit = {
   headers?: HeadersInit;
-  status?: 301 | 302 | 303 | 307 | 308;
-} & Omit<ResponseInit, "headers" | "status"> & RedirectOptions;
+  status?: RedirectStatus;
+  maxLocationBytes?: number;
+};
 
-function hasCRLF(s: string): boolean {
-  return /[\r\n]/.test(s);
+type ExternalRedirectInit = RedirectInit & {
+  allowedOrigins: readonly string[];
+  allowHttp?: boolean;
+  preserveMethod?: boolean;
+};
+
+type RedirectErrorCode =
+  | "credentials_not_allowed"
+  | "external_method_preservation_not_allowed"
+  | "external_origin_not_allowed"
+  | "external_scheme_not_allowed"
+  | "invalid_external_target"
+  | "invalid_local_target"
+  | "invalid_redirect_status"
+  | "location_too_long";
+
+class RedirectError extends TypeError {
+  readonly code: RedirectErrorCode;
+
+  constructor(code: RedirectErrorCode) {
+    const messages: Record<RedirectErrorCode, string> = {
+      credentials_not_allowed: "redirect URL credentials are not allowed",
+      external_method_preservation_not_allowed:
+        "external 307 and 308 redirects require preserveMethod",
+      external_origin_not_allowed: "redirect origin is not allowlisted",
+      external_scheme_not_allowed: "redirect URL must use HTTPS",
+      invalid_external_target: "invalid external redirect target",
+      invalid_local_target: "invalid local redirect target",
+      invalid_redirect_status: "invalid redirect status",
+      location_too_long: "redirect Location exceeds the configured byte limit",
+    };
+    super(messages[code]);
+    this.name = "RedirectError";
+    this.code = code;
+  }
 }
 
-function isAbsoluteUrl(s: string): boolean {
+type LocalRedirect = {
+  (target: LocalRedirectTarget | string, init?: RedirectInit | RedirectStatus):
+    ResponseFunction<never>;
+};
+
+type ExternalRedirect = {
+  (target: string | URL, init: ExternalRedirectInit): ResponseFunction<never>;
+};
+
+type Redirect = LocalRedirect & {
+  local: LocalRedirect;
+  external: ExternalRedirect;
+};
+
+function fail(code: RedirectErrorCode): never {
+  throw new RedirectError(code);
+}
+
+function hasForbiddenControl(value: string) {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function locationBytes(location: string) {
+  return new TextEncoder().encode(location).byteLength;
+}
+
+function maxLocationBytes(value: unknown): number {
+  const maximum = value === undefined ? DEFAULT_MAX_LOCATION_BYTES : value;
+  if (
+    typeof maximum !== "number"
+    || !Number.isSafeInteger(maximum)
+    || maximum <= 0
+  ) {
+    fail("location_too_long");
+  }
+  return maximum;
+}
+
+function status(value: unknown): RedirectStatus {
+  const redirectStatus = value ?? 302;
+  if (!isRedirectStatus(redirectStatus as number)) {
+    fail("invalid_redirect_status");
+  }
+  return redirectStatus as RedirectStatus;
+}
+
+function normalizeInit(value: unknown): RedirectInit {
+  if (typeof value === "number") return { status: status(value) };
+  if (value === undefined) return {};
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail("invalid_redirect_status");
+  }
+  return value as RedirectInit;
+}
+
+function checkRawLocalTarget(target: string) {
+  if (
+    target.trim() !== target
+    || !target.startsWith("/")
+    || target.startsWith("//")
+    || target.includes("\\")
+    || hasForbiddenControl(target)
+    || INVALID_PERCENT_ESCAPE.test(target)
+  ) {
+    fail("invalid_local_target");
+  }
+}
+
+function checkSerializedLocal(
+  location: string,
+  base: URL,
+  maximum: number,
+) {
+  if (
+    !location.startsWith("/")
+    || location.startsWith("//")
+    || location.includes("\\")
+    || hasForbiddenControl(location)
+    || INVALID_PERCENT_ESCAPE.test(location)
+  ) {
+    fail("invalid_local_target");
+  }
+
+  let resolved: URL;
   try {
-    new URL(s);
-    return true;
+    resolved = new URL(location, base);
   } catch {
-    return false;
-  }
-}
-
-function encodePathname(s: string): string {
-  // expect strict origin-form path ("/..."), disallow protocol-relative and
-  // backslashes
-  if (!s.startsWith("/") || s.startsWith("//") || s.includes("\\")) {
-    throw new Error("invalid pathname");
-  }
-  // encode per segment to avoid double-encoding present percent-escapes
-  return s.split("/")
-    .map((each, i) => i === 0 ? "" : encodeURIComponent(each)).join("/");
-}
-
-function toSearch(query?: RedirectObject["query"]) {
-  if (!query) return "";
-
-  const search = Object.entries(query)
-    .filter(([, v]) => v !== null && v !== undefined)
-    .reduce((params, [k, v]) => {
-      params.append(k, String(v));
-      return params;
-    }, new URLSearchParams())
-    .toString()
-    ;
-
-  return is.text(search) ? "?" + search : "";
-}
-
-function toNormalized(relative: string, base?: string | URL): string {
-  // base -> URL resolution
-  if (base !== undefined) {
-    const url = new URL(relative, new URL(String(base)));
-    return url.pathname + url.search;
-  }
-  // no base -> enforce strict single-slash path and strip fragment
-  if (!relative.startsWith("/") || relative.startsWith("//")) {
-    throw new Error("bad relative");
+    fail("invalid_local_target");
   }
 
-  const i = relative.indexOf("#");
-  return i === -1 ? relative : relative.slice(0, i);
+  if (
+    resolved.origin !== base.origin
+    || !resolved.pathname.startsWith("/")
+    || resolved.pathname.startsWith("//")
+    || resolved.pathname.includes("\\")
+    || ENCODED_BACKSLASH.test(resolved.pathname)
+    || ENCODED_PATH_CONTROL.test(resolved.pathname)
+  ) {
+    fail("invalid_local_target");
+  }
+
+  if (locationBytes(location) > maximum) fail("location_too_long");
 }
 
-/**
-* Redirect request
-* @param location location to redirect to
-* @param status redirection 3xx code
-* @return Response rendering function
-*/
-export default (location: string, status?: Redirection): ResponseFunction<never> =>
-  // no body
-  app => app.respond(null, {
-    headers: {
-      "Content-Length": String(0),
-      Location: location,
-      "Cache-Control": "no-cache",
-    },
-    status: status ?? http.Status.FOUND,
-  });
+function appendQuery(url: URL, query: unknown) {
+  if (query === undefined) return;
+  if (query === null || typeof query !== "object" || Array.isArray(query)) {
+    fail("invalid_local_target");
+  }
+
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    const values = Array.isArray(value) ? value : [value];
+    for (const item of values) {
+      if (item === null || item === undefined) continue;
+      if (!["boolean", "number", "string"].includes(typeof item)) {
+        fail("invalid_local_target");
+      }
+      if (typeof item === "number" && !Number.isFinite(item)) {
+        fail("invalid_local_target");
+      }
+      params.append(key, String(item));
+    }
+  }
+  url.search = params.toString();
+}
+
+function serializeLocal(target: unknown, maximum: number) {
+  let url: URL;
+  if (typeof target === "string") {
+    checkRawLocalTarget(target);
+    try {
+      url = new URL(target, LOCAL_BASE);
+    } catch {
+      fail("invalid_local_target");
+    }
+  } else {
+    if (
+      target === null
+      || target instanceof URL
+      || typeof target !== "object"
+      || !("pathname" in target)
+      || typeof target.pathname !== "string"
+      || target.pathname.includes("?")
+      || target.pathname.includes("#")
+    ) {
+      fail("invalid_local_target");
+    }
+    const object = target as {
+      pathname: string;
+      query?: unknown;
+      hash?: unknown;
+    };
+    checkRawLocalTarget(object.pathname);
+    try {
+      url = new URL(object.pathname, LOCAL_BASE);
+    } catch {
+      fail("invalid_local_target");
+    }
+    appendQuery(url, object.query);
+    if (object.hash !== undefined) {
+      if (
+        typeof object.hash !== "string"
+        || hasForbiddenControl(object.hash)
+      ) {
+        fail("invalid_local_target");
+      }
+      url.hash = object.hash.startsWith("#")
+        ? object.hash
+        : `#${object.hash}`;
+    }
+  }
+
+  const location = url.pathname + url.search + url.hash;
+  checkSerializedLocal(location, LOCAL_BASE, maximum);
+  return location;
+}
+
+function response(
+  location: string,
+  redirectStatus: RedirectStatus,
+  headersInit: HeadersInit | undefined,
+): ResponseFunction<never> {
+  return app => {
+    const headers = new Headers(headersInit);
+    headers.set("Location", location);
+    headers.set("Content-Length", "0");
+    if (!headers.has("Cache-Control")) headers.set("Cache-Control", "no-cache");
+
+    return app.respond(null, {
+      headers: Object.fromEntries(headers),
+      status: redirectStatus,
+    });
+  };
+}
+
+const local = ((target: unknown, options: unknown) => {
+  const normalized = normalizeInit(options);
+  const redirectStatus = status(normalized.status);
+  const maximum = maxLocationBytes(normalized.maxLocationBytes);
+  const location = serializeLocal(target, maximum);
+
+  return (app, transfer, request) => {
+    checkSerializedLocal(location, request.url, maximum);
+    return response(location, redirectStatus, normalized.headers)(
+      app,
+      transfer,
+      request,
+    );
+  };
+}) as LocalRedirect;
+
+function parseExternalOrigin(origin: unknown, allowHttp: boolean) {
+  if (
+    typeof origin !== "string"
+    || origin.trim() !== origin
+    || hasForbiddenControl(origin)
+    || origin.includes("\\")
+    || !ORIGIN_FORM.test(origin)
+  ) {
+    fail("invalid_external_target");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    fail("invalid_external_target");
+  }
+
+  const allowedProtocol = url.protocol === "https:"
+    || allowHttp && url.protocol === "http:";
+  if (!allowedProtocol) fail("external_scheme_not_allowed");
+  if (url.username !== "" || url.password !== "") fail("credentials_not_allowed");
+  if (url.pathname !== "/" || url.search !== "" || url.hash !== "") {
+    fail("invalid_external_target");
+  }
+  return url.origin;
+}
+
+function serializeExternal(target: unknown, options: ExternalRedirectInit) {
+  const raw = target instanceof URL ? target.href : target;
+  if (
+    typeof raw !== "string"
+    || raw.trim() !== raw
+    || hasForbiddenControl(raw)
+    || raw.includes("\\")
+  ) {
+    fail("invalid_external_target");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    fail("invalid_external_target");
+  }
+
+  const allowHttp = options.allowHttp === true;
+  const allowedProtocol = url.protocol === "https:"
+    || allowHttp && url.protocol === "http:";
+  if (!allowedProtocol) fail("external_scheme_not_allowed");
+  if (url.username !== "" || url.password !== "") fail("credentials_not_allowed");
+  if (!Array.isArray(options.allowedOrigins) || options.allowedOrigins.length === 0) {
+    fail("external_origin_not_allowed");
+  }
+
+  const origins = new Set(options.allowedOrigins
+    .map(origin => parseExternalOrigin(origin, allowHttp)));
+  if (!origins.has(url.origin)) fail("external_origin_not_allowed");
+
+  // An explicit empty fragment prevents user agents from inheriting a source
+  // fragment when the destination itself has no fragment.
+  const location = url.hash === "" && !url.href.endsWith("#")
+    ? `${url.href}#`
+    : url.href;
+  if (locationBytes(location) > maxLocationBytes(options.maxLocationBytes)) {
+    fail("location_too_long");
+  }
+  return location;
+}
+
+const external = ((target: unknown, options: unknown) => {
+  if (options === null || typeof options !== "object" || Array.isArray(options)) {
+    fail("external_origin_not_allowed");
+  }
+  const normalized = options as ExternalRedirectInit;
+  const redirectStatus = status(normalized.status);
+  const location = serializeExternal(target, normalized);
+  if (
+    METHOD_PRESERVING_STATUSES.has(redirectStatus)
+    && normalized.preserveMethod !== true
+  ) {
+    fail("external_method_preservation_not_allowed");
+  }
+
+  return response(location, redirectStatus, normalized.headers);
+}) as ExternalRedirect;
+
+const redirect = Object.assign(local, { local, external }) as Redirect;
+
+export {
+  RedirectError,
+  type ExternalRedirectInit,
+  type LocalRedirectTarget,
+  type RedirectInit,
+  type RedirectQueryValue,
+  type RedirectStatus,
+};
+export default redirect;

--- a/packages/core/src/private/response/respond.spec.ts
+++ b/packages/core/src/private/response/respond.spec.ts
@@ -1,23 +1,9 @@
+import { Code } from "#errors";
 import respond from "#response/respond";
-import http from "@rcompat/http";
 import test from "@rcompat/test";
-
-const app = {
-  respond(body: any, { headers = {}, status = http.Status.OK } = {}) {
-    return new Response(body, {
-      headers: {
-        "content-type": http.MIME.TEXT_HTML, ...headers,
-      },
-      status,
-    });
-  },
-};
 
 const url = "https://primate.run/";
 
-test.case("guess URL", async assert => {
-  const response = await (respond(new URL(url)) as any)(app)!;
-  // assert(await response.text()).null();
-  assert(response.status).equals(http.Status.FOUND);
-  assert(response.headers.get("location")).equals(url);
+test.case("implicit URL redirects are disabled", assert => {
+  assert(() => respond(new URL(url) as never)).throws(Code.response_implicit_url);
 });

--- a/packages/core/src/private/response/respond.ts
+++ b/packages/core/src/private/response/respond.ts
@@ -2,7 +2,6 @@ import E from "#errors";
 import binary from "#response/binary";
 import json from "#response/json";
 import $null from "#response/null";
-import redirect from "#response/redirect";
 import type ResponseFunction from "#response/ResponseFunction";
 import type ResponseLike from "#response/ResponseLike";
 import text from "#response/text";
@@ -31,7 +30,7 @@ function match<T extends ReadonlyFunctions>(m: MatchResult<T>): MatchResult<T> {
 // [if, then]
 const guesses = match([
   [is.null, $null],
-  [is.url, value => redirect(value.toString())],
+  [is.url, () => { throw E.response_implicit_url(); }],
   [fs.isStream, value => binary(value)],
   [is.response, value => _ => value],
   [is.dict, json],

--- a/packages/core/src/public/response.ts
+++ b/packages/core/src/public/response.ts
@@ -9,6 +9,14 @@ import view from "#response/view";
 import ws from "#response/ws";
 import $null from "#response/null";
 
+export type {
+  ExternalRedirectInit,
+  LocalRedirectTarget,
+  RedirectInit,
+  RedirectQueryValue,
+  RedirectStatus,
+} from "#response/redirect";
+
 const response = {
   binary,
   error,

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -20,7 +20,8 @@
     "build": "npm run clean && tsc",
     "clean": "rm -rf ./lib",
     "lint": "eslint .",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "npx proby"
   },
   "dependencies": {
     "@primate/core": "workspace:^",

--- a/packages/go/src/private/to-response.spec.ts
+++ b/packages/go/src/private/to-response.spec.ts
@@ -1,0 +1,21 @@
+import to_response from "#to-response";
+import test from "@rcompat/test";
+
+const app = {
+  respond(body: BodyInit | null, init?: ResponseInit) {
+    return new Response(body, init);
+  },
+};
+const request = { url: new URL("https://app.example/") };
+
+function redirect(location: string, status?: number) {
+  return to_response({ handler: "redirect", location, status }) as any;
+}
+
+test.case("go redirects use core local validation", assert => {
+  const response = redirect("/safe", 303)(app, {}, request);
+  assert(response.status).equals(303);
+  assert(response.headers.get("Location")).equals("/safe");
+  assert(() => redirect("/\\evil.example")).throws(Error);
+  assert(() => redirect("/safe", 399)).throws(Error);
+});

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -20,7 +20,8 @@
     "build": "npm run clean && tsc",
     "clean": "rm -rf ./lib",
     "lint": "eslint .",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "npx proby"
   },
   "dependencies": {
     "@primate/core": "workspace:^",

--- a/packages/python/src/private/to-response.spec.ts
+++ b/packages/python/src/private/to-response.spec.ts
@@ -1,0 +1,21 @@
+import to_response from "#to-response";
+import test from "@rcompat/test";
+
+const app = {
+  respond(body: BodyInit | null, init?: ResponseInit) {
+    return new Response(body, init);
+  },
+};
+const request = { url: new URL("https://app.example/") };
+
+function redirect(location: string, status?: number) {
+  return to_response({ __PRMT__: "redirect", location, status } as any) as any;
+}
+
+test.case("python redirects use core local validation", assert => {
+  const response = redirect("/safe", 303)(app, {}, request);
+  assert(response.status).equals(303);
+  assert(response.headers.get("Location")).equals("/safe");
+  assert(() => redirect("//evil.example")).throws(Error);
+  assert(() => redirect("/safe", 300)).throws(Error);
+});

--- a/packages/ruby/package.json
+++ b/packages/ruby/package.json
@@ -20,7 +20,8 @@
     "build": "npm run clean && tsc",
     "clean": "rm -rf ./lib",
     "lint": "eslint .",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "npx proby"
   },
   "dependencies": {
     "@primate/core": "workspace:^",

--- a/packages/ruby/src/private/to-response.spec.ts
+++ b/packages/ruby/src/private/to-response.spec.ts
@@ -1,0 +1,21 @@
+import to_response from "#to-response";
+import test from "@rcompat/test";
+
+const app = {
+  respond(body: BodyInit | null, init?: ResponseInit) {
+    return new Response(body, init);
+  },
+};
+const request = { url: new URL("https://app.example/") };
+
+function redirect(location: string, status?: number) {
+  return to_response({ __PRMT__: "redirect", location, status }) as any;
+}
+
+test.case("ruby redirects use core local validation", assert => {
+  const response = redirect("/safe", 303)(app, {}, request);
+  assert(response.status).equals(303);
+  assert(response.headers.get("Location")).equals("/safe");
+  assert(() => redirect("//evil.example")).throws(Error);
+  assert(() => redirect("/safe", 304)).throws(Error);
+});


### PR DESCRIPTION
## Summary

- make local redirects safe by default through `response.redirect.local(...)`, while retaining `response.redirect(...)` as a local-safe compatibility alias
- add `response.redirect.external(...)` with an exact origin allowlist, HTTPS-by-default policy, credential/scheme checks, explicit HTTP development opt-in, and explicit method-preservation opt-in for external 307/308 responses
- serialize structured local query values with `URLSearchParams`, enforce exact redirect statuses, validate final serialized locations, and cap `Location` by UTF-8 byte length
- disable implicit redirects from returned `URL` objects and use the shared exact redirect-status predicate in client redirect following
- correct the login redirect guide and directly affected TypeScript, JavaScript, Python, Ruby, and Go documentation/examples

## Security impact

This hardens redirect generation against CWE-601 open redirects. Local targets must remain origin-relative after WHATWG normalization and are rejected for protocol-relative output, schemes, backslashes, forbidden control characters, malformed percent escapes, encoded path ambiguity, or cross-origin resolution. External redirects require an exact normalized origin allowlist; substring, suffix, credentials, and non-HTTP-family schemes are not accepted.

External 307/308 responses require `preserveMethod: true` because those statuses can replay a request method and body. Redirect recognition is limited to 301, 302, 303, 307, and 308 on both server and client. Final `Location` values are revalidated and limited to 2048 UTF-8 bytes by default.

This does not claim remote code execution or confirmed HTTP response splitting.

## Audit follow-up

A second security review found and corrected additional edge cases:

- explicit `null`, string, and non-finite redirect statuses are rejected rather than defaulting to 302
- structured local targets must be plain records, URL-like objects are rejected, and explicit empty query/fragment markers are preserved
- malformed external percent escapes, non-canonical authority forms, empty userinfo, sparse allowlists, and URL-like target confusion are rejected
- repeated `Set-Cookie` response fields survive header normalization
- malformed `Location` is parsed only for exact redirect statuses and now produces a deterministic error
- non-GET client requests force Fetch `mode: "same-origin"`, preventing automatic 307/308 body replay to another origin while preserving browser-managed same-origin redirects

Chromium 150 was exercised against live same-origin and cross-origin 307 servers: the same-origin request preserved its POST body, while the cross-origin redirect failed without delivering the body. Bun and Deno server-side Fetch currently ignore `mode: "same-origin"`; the transport module is browser-only, and server redirect generation remains independently validated.

## Compatibility

Existing local calls continue to work:

```ts
response.redirect("/account");
response.redirect("/account", 303);
```

The preferred explicit form is:

```ts
response.redirect.local({
  pathname: "/login",
  query: { next: request.target },
}, { status: 303 });
```

Absolute redirect strings are now rejected by the default helper. Migrate intentional external redirects to:

```ts
response.redirect.external("https://example.com/path", {
  allowedOrigins: ["https://example.com"],
});
```

Returning a `URL` no longer creates an implicit redirect; it fails with migration guidance. Python, Ruby, and Go binding redirects continue to support simple local targets and now receive the same core runtime target/status validation. Their current binding APIs do not expose the new external policy object.

External destinations without a fragment are emitted with an explicit empty fragment to prevent source-fragment inheritance.

## Tests

Passed:

- `cd packages/core && bun --conditions @primate/source ../../node_modules/proby/lib/bin.js` — 379 passed
- `cd packages/core && node --conditions=@primate/source ../../node_modules/proby/lib/bin.js` — 379 passed on Node.js 24.4.1
- `cd packages/core && bunx deno run -A --conditions=@primate/source npm:proby` — 379 passed on Deno 2.9.3
- `cd packages/core && bun ../../node_modules/typescript/bin/tsc6 --noEmit`
- `pnpm --filter @primate/core test` — 379 passed
- `pnpm --filter @primate/core build`
- Python, Ruby, and Go adapter unit tests — 1 passed per adapter under Node.js, Bun, and Deno
- Python, Ruby, and Go TypeScript compilation and package builds
- focused backend redirect integration test under Node.js, Bun, and Deno — 1 passed per runtime
- runtime redirect/header smoke test under Node.js, Bun, and Deno; all three rejected newline-containing `Headers` values consistently
- `pnpm --filter @app/website build`
- changed-file `eslint --quiet`
- `git diff --check`

Repository-wide commands attempted with environment/baseline limitations:

- `pnpm lint` — timed out after 30 minutes; direct `bun eslint .` completed but reported 389 errors and 531 warnings in unrelated untouched files
- `pnpm test:packages` — core and pema passed, then MongoDB tests stopped because Podman is not installed
- `pnpm test` — stopped at the same missing-Podman MongoDB setup after core passed
- `pnpm test:apps` — stopped in unrelated app setup (`@primate/core/Database` resolution) and the Go app cannot run because Go is not installed
- `pnpm test:backend` — Go, `uv`, and Bundler are not installed; the focused redirect backend test above passed independently
- `pnpm build:packages` / `pnpm build` — stopped in the existing Angular package `cp src/types/{app,index}.d.ts` command under `/bin/sh`; affected package builds and the website build passed independently
- full JS/TS backend suites reached and passed the redirect assertions but failed unrelated Svelte 5.56 server-rendering and MIME expectation cases

Closes #194
